### PR TITLE
Handle case where editor has no config for this LSP

### DIFF
--- a/shader-language-server/src/server.rs
+++ b/shader-language-server/src/server.rs
@@ -554,9 +554,10 @@ impl ServerLanguage {
             config,
             |server: &mut ServerLanguage, value: Value| {
                 // Sent 1 item, received 1 in an array
-                let mut parsed_config: Vec<ServerConfig> =
+                let mut parsed_config: Vec<Option<ServerConfig>> =
                     serde_json::from_value(value).expect("Failed to parse received config");
-                let config = parsed_config.remove(0);
+                let config = parsed_config.remove(0).unwrap_or_default();
+
                 info!("Updating server config: {:#?}", config);
                 for (_language, language_data) in &mut server.language_data {
                     language_data.config = config.clone();


### PR DESCRIPTION
Hey, this project is awesome! I was able to get the server running with Sublime Text's LSP package with only a small change.

I configured the LSP for use with Sublime Text:

```json
"clients": {
	"shader-sense": {
		"enabled": true,
		"command": ["shader-language-server"],
		"selector": "source.hlsl",
		"env": {
			"RUST_LOG": "debug",
		}
	}
}
```

but hit a panic when enabling the server related to the client response for server configuration returning `[null]`.

This PR makes the server handle that case. I don't know enough about LSP to know if Sublime's LSP implementation is doing something funny here, but it seemed like a harmless enough change.