### PR TITLE
Remove path canonicalization for path remapping prefixes

### DIFF
--- a/shader-language-server/src/server/server_config.rs
+++ b/shader-language-server/src/server/server_config.rs
@@ -137,7 +137,7 @@ impl ServerSerializedConfig {
                 .path_remapping
                 .map(|i| {
                     i.into_iter()
-                        .map(|(v, i)| (verify_user_path(&v), verify_user_path(&i)))
+                        .map(|(v, i)| (PathBuf::from(v), verify_user_path(&i)))
                         .collect()
                 })
                 .unwrap_or_default(),
@@ -215,7 +215,7 @@ impl ServerSerializedConfig {
                     .path_remapping
                     .map(|i| {
                         i.into_iter()
-                            .map(|(v, i)| (verify_user_path(&v), verify_user_path(&i)))
+                            .map(|(v, i)| (PathBuf::from(v), verify_user_path(&i)))
                             .collect::<HashMap<PathBuf, PathBuf>>()
                     })
                     .unwrap_or_default(),


### PR DESCRIPTION
On Windows, path remapping seems to be broken due to replacing the `/` prefix with `C:/` in the remapping key.

Since these are virtual paths, is canonicalization necessary? Is there anything that relies on the existing behavior?

This PR simply removes that step. In my limited testing, this fixes the issue (https://github.com/antaalt/shader-sense/issues/37) I am experiencing.