### PR TITLE
Re-parse tree when opening a cached dependency as a main file

### DIFF
--- a/shader-language-server/src/server/server_file_cache.rs
+++ b/shader-language-server/src/server/server_file_cache.rs
@@ -814,12 +814,28 @@ impl ServerLanguageFileCache {
                     uri
                 );
                 cached_file.is_main_file = true;
-                // Replace its content from request to make sure content is correct.
-                debug_assert!(
-                    RefCell::borrow_mut(&cached_file.shader_module).content == *text,
-                    "Server deps content different from client provided one."
-                );
-                RefCell::borrow_mut(&cached_file.shader_module).content = text.into();
+                // When the cached module was loaded as an include dependency,
+                // its content was read from disk via `read_string_lossy` /
+                // `std::fs::read_to_string`, which preserves the on-disk bytes
+                // verbatim (e.g. CRLF on Windows). The client-provided didOpen
+                // text may have been normalized by the editor (e.g. CRLF -> LF),
+                // so the two buffers can differ in length. We cannot simply
+                // replace `.content` and keep the existing tree-sitter tree:
+                // the stored tree's byte offsets would still refer to the
+                // longer pre-normalization buffer, and subsequent symbol
+                // queries (e.g. `symbol_parser::get_name`) would slice the
+                // new, shorter content out of bounds and panic with
+                // "byte index N is out of bounds of ...".
+                //
+                // When the content actually differs, re-parse from scratch so
+                // the tree and content stay in sync. When they match byte-for-
+                // byte, skip the re-parse as an optimization.
+                {
+                    let mut module = RefCell::borrow_mut(&cached_file.shader_module);
+                    if module.content != *text {
+                        *module = shader_module_parser.create_module(&file_path, text)?;
+                    }
+                }
                 info!(
                     "Starting watching {:#?} dependency file as main file at {}. {} files in cache.",
                     lang,


### PR DESCRIPTION
## Summary

Fix a 100%-reproducible panic in `shader-language-server` when an LSP client opens a shader file that was previously pulled into the cache as an include dependency. The panic message is:

```
thread 'main' panicked at shader-sense/src/symbols/symbol_parser.rs:25:20:
byte index N is out of bounds of `...`
```

It kills the LS process and fails any client operation in flight.

## Root cause

`watch_main_file` in `shader-language-server/src/server/server_file_cache.rs` has an "already cached" branch that handles the case where a file has previously been loaded as an include dependency via `watch_dependency`:

```rust
cached_file.is_main_file = true;
// Replace its content from request to make sure content is correct.
debug_assert!(
    RefCell::borrow_mut(&cached_file.shader_module).content == *text,
    "Server deps content different from client provided one."
);
RefCell::borrow_mut(&cached_file.shader_module).content = text.into();
```

Two distinct code paths populate the cache:

1. **Dependency path** (`watch_dependency`) reads the file from disk via `read_string_lossy` → `std::fs::read_to_string`, which preserves the on-disk bytes **verbatim** (CRLF on Windows).
2. **Main-file path** (`watch_main_file`) receives `text` from the client's `textDocument/didOpen` notification.

The `debug_assert!` encodes the assumption that these two buffers are byte-identical. In practice they are not: any LSP client whose file reader normalizes line endings will send shorter text than what was read from disk. Python's default text-mode `open()`, for example, applies universal-newlines translation (CRLF → LF), shrinking the buffer by 1 byte per line.

In release builds the assertion is silently violated. The assignment replaces `content` with the shorter buffer but **the tree-sitter tree is not re-parsed** — its nodes still reference byte offsets into the original longer buffer. The next symbol query walks that stale tree and calls `get_name` at `shader-sense/src/symbols/symbol_parser.rs:25`:

```rust
pub(super) fn get_name<'a>(shader_content: &'a str, node: Node) -> &'a str {
    let range = node.range();
    &shader_content[range.start_byte..range.end_byte]  // <-- panic here
}
```

Nodes near the end of the file produce `range.end_byte` beyond the new, shorter content, and the slice panics.

### Arithmetic confirmation

I observed the panic with a 543-line CRLF `.hlsl` file in a Unity HDRP project:

| | |
|---|---|
| On-disk size (CRLF) | 19,390 bytes |
| After CRLF → LF normalization | 19,390 − 543 = **18,847** bytes |
| Reported panic index | **18,849** (≈ the old EOF, two bytes past the new length) |

## Fix

When taking the already-cached branch, re-parse the module via `create_module` whenever the cached content differs from the client-provided text. This keeps the tree and content consistent. When they match byte-for-byte, the re-parse is skipped, so there's no cost for well-behaved clients.

```rust
{
    let mut module = RefCell::borrow_mut(&cached_file.shader_module);
    if module.content != *text {
        *module = shader_module_parser.create_module(&file_path, text)?;
    }
}
```

The `debug_assert!` is dropped because the invariant it encoded is not one the server can assume about arbitrary LSP clients — newline normalization is a routine client behavior.

I used `create_module` (the same path `watch_dependency` takes) rather than `update_module_partial` because the two buffers describe different content, so there is no valid incremental tree edit to apply; a fresh parse is both simpler and correct.

## Reproduction

Minimal sequence (before the fix, against v1.3.0 and current `main`):

1. `didOpen` a `.shader` / `.compute` that `#include`s a `.hlsl`, on Windows (file on disk has CRLF), via an LSP client that normalizes newlines (e.g. any Python-based client using `open(path)` in text mode).
2. `didOpen` that `.hlsl` directly as a main document.
3. Send `textDocument/documentSymbol` → panic, process exits.

I'm happy to contribute a regression test if that would help — let me know what style you'd prefer (an integration test under `shader-language-server/tests/` that drives the server over stdio, or a unit test at the cache level that seeds the dep then opens it as main).

## Verification

- `cargo check -p shader_language_server` clean on `x86_64-pc-windows-msvc`.
- `cargo test -p shader-sense --lib` on an **unmodified** `main` produces **36 passed, 8 failed** — all 8 failures are `validator::tests::hlsl_*` which dynamic-load `dxcompiler.dll` (not bundled in the build tree). With this patch applied the results are identical (**36 passed, 8 failed**, same tests) — no regressions from the change.
- **End-to-end**: I built the release binary from this branch, ran the exact crash-inducing LSP sequence above (bare stdio, no editor/client in between), and confirmed `textDocument/documentSymbol` for the previously-crashing file now returns its 174 symbols cleanly instead of killing the server.

## Context

This is also being worked around client-side in [oraios/serena#1305](https://github.com/oraios/serena/pull/1305) by preserving CRLF in the `didOpen.text` the client sends. That workaround unblocks users today, but the root-cause fix belongs here — any client that normalizes newlines on Windows will otherwise hit this, not just Serena.