### PR TITLE
Fix empty document symbol names for GLSL precision statements

### DIFF
--- a/shader-language-server/src/server/provider/document_symbol.rs
+++ b/shader-language-server/src/server/provider/document_symbol.rs
@@ -18,6 +18,7 @@ impl ServerLanguage {
             .filter(|symbol| {
                 // Dont publish keywords & transient.
                 !symbol.is_type(ShaderSymbolType::Keyword)
+                    && !symbol.label.trim().is_empty()
                     && !symbol.is_transient()
                     && match &symbol.mode {
                         ShaderSymbolMode::Runtime(_) => true,

--- a/shader-language-server/tests/server_communication.rs
+++ b/shader-language-server/tests/server_communication.rs
@@ -63,6 +63,26 @@ fn get_workspace_symbol_params() -> WorkspaceSymbolParams {
         partial_result_params: PartialResultParams::default(),
     }
 }
+fn assert_no_empty_document_symbol_name(response: Option<DocumentSymbolResponse>) {
+    let symbols = response.unwrap();
+    let empty_names: Vec<String> = match symbols {
+        DocumentSymbolResponse::Nested(document_symbol) => document_symbol
+            .iter()
+            .filter(|symbol| symbol.name.trim().is_empty())
+            .map(|symbol| symbol.detail.clone().unwrap_or_default())
+            .collect(),
+        DocumentSymbolResponse::Flat(workspace_symbol) => workspace_symbol
+            .iter()
+            .filter(|symbol| symbol.name.trim().is_empty())
+            .map(|symbol| symbol.name.clone())
+            .collect(),
+    };
+    assert!(
+        empty_names.is_empty(),
+        "Document symbols must not contain empty names. Offending details: {:#?}",
+        empty_names
+    );
+}
 fn get_diagnostic_report(
     result: DocumentDiagnosticReportResult,
 ) -> RelatedFullDocumentDiagnosticReport {
@@ -130,6 +150,27 @@ fn test_variant() {
     });
     server.send_notification::<DidChangeShaderVariant>(&DidChangeShaderVariantParams {
         shader_variant: None, // Clear for next tests
+    });
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: file.identifier(),
+    });
+}
+
+#[test]
+fn test_glsl_precision_statement_document_symbols_have_names() {
+    let mut server = TestServer::desktop().unwrap();
+
+    let file = TestFile::new(
+        Path::new("../shader-sense/test/glsl/precision-only.glsl"),
+        ShadingLanguage::Glsl,
+    );
+    let document_symbol_params = get_document_symbol_params(&file);
+
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: file.item(),
+    });
+    server.send_request::<DocumentSymbolRequest>(&document_symbol_params, |response| {
+        assert_no_empty_document_symbol_name(response.unwrap());
     });
     server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
         text_document: file.identifier(),

--- a/shader-sense/test/glsl/precision-only.glsl
+++ b/shader-sense/test/glsl/precision-only.glsl
@@ -1,0 +1,2 @@
+precision highp float;
+precision highp int;


### PR DESCRIPTION
This prevents GLSL `precision` statements from producing document symbols with empty names.

`precision` statements are not named declarations, so emitting them as symbols creates invalid or confusing document symbol results for LSP clients.

Changes in this PR:
- filter out empty-name document symbols generated from GLSL precision statements
- add regression coverage for the affected case

Validation:
- added/updated server communication coverage for the GLSL precision-symbol case
- verified the targeted test passes