### PR TITLE
Use includer context for GLSL dependency diagnostics

### DIFF
--- a/shader-language-server/src/server/provider/diagnostic.rs
+++ b/shader-language-server/src/server/provider/diagnostic.rs
@@ -45,7 +45,11 @@ impl ServerLanguage {
         &mut self,
         uri: &Url,
     ) -> Result<DocumentDiagnosticReportResult, ServerLanguageError> {
-        let context_uri = self.watched_files.get_document_diagnostic_context(uri);
+        let context_uri = if self.config.get_dependency_context_diagnostics() {
+            self.watched_files.get_document_diagnostic_context(uri)
+        } else {
+            uri.clone()
+        };
         let mut diagnostics = self.recolt_diagnostic(&context_uri)?;
         let main_diagnostic = match diagnostics.remove(&uri) {
             Some(diag) => diag,

--- a/shader-language-server/src/server/provider/diagnostic.rs
+++ b/shader-language-server/src/server/provider/diagnostic.rs
@@ -45,14 +45,15 @@ impl ServerLanguage {
         &mut self,
         uri: &Url,
     ) -> Result<DocumentDiagnosticReportResult, ServerLanguageError> {
-        let mut diagnostics = self.recolt_diagnostic(&uri)?;
+        let context_uri = self.watched_files.get_document_diagnostic_context(uri);
+        let mut diagnostics = self.recolt_diagnostic(&context_uri)?;
         let main_diagnostic = match diagnostics.remove(&uri) {
             Some(diag) => diag,
             None => vec![],
         };
         Ok(DocumentDiagnosticReportResult::Report(
             DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
-                related_documents: Some(
+                related_documents: (context_uri == *uri).then_some(
                     diagnostics
                         .into_iter()
                         .map(|diagnostic| {

--- a/shader-language-server/src/server/server_config.rs
+++ b/shader-language-server/src/server/server_config.rs
@@ -92,6 +92,7 @@ pub struct ServerSerializedConfig {
     validate: Option<bool>,                   // Validation via standard API
     symbols: Option<bool>,                    // Query symbols
     symbol_diagnostics: Option<bool>,         // Debug option to visualise issues with tree-sitter
+    dependency_context_diagnostics: Option<bool>, // Reuse a dependent main-file context for document diagnostics.
     experimental_macro_expansion: Option<bool>, // Experimental test for the new feature.
     stage_define: Option<HashMap<ShaderStage, HashMap<String, String>>>, // Specific macro defined per shader stage
     trace: Option<ServerTrace>,      // Level of error to display
@@ -111,6 +112,7 @@ pub struct ServerConfig {
     validate: bool,
     symbols: bool,
     symbol_diagnostics: bool,
+    dependency_context_diagnostics: bool,
     experimental_macro_expansion: bool,
     trace: ServerTrace,
     severity: ShaderDiagnosticSeverity,
@@ -150,6 +152,9 @@ impl ServerSerializedConfig {
             symbol_diagnostics: self
                 .symbol_diagnostics
                 .unwrap_or(ServerConfig::DEFAULT_SYMBOL_DIAGNOSTIC),
+            dependency_context_diagnostics: self
+                .dependency_context_diagnostics
+                .unwrap_or(ServerConfig::DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS),
             trace: self.trace.unwrap_or(ServerConfig::DEFAULT_TRACE),
             stage_define: self.stage_define.unwrap_or_default(),
             severity: self
@@ -275,6 +280,7 @@ impl ServerConfig {
     pub const DEFAULT_SYMBOLS: bool = true;
     pub const DEFAULT_VALIDATE: bool = true;
     pub const DEFAULT_SYMBOL_DIAGNOSTIC: bool = false; // Mostly for debug
+    pub const DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS: bool = false;
     pub const DEFAULT_SEVERITY: ShaderDiagnosticSeverity = ShaderDiagnosticSeverity::Error;
     pub const DEFAULT_TRACE: ServerTrace = ServerTrace {
         server: ServerTraceLevel::Off,
@@ -338,6 +344,9 @@ impl ServerConfig {
     pub fn get_symbol_diagnostics(&self) -> bool {
         self.symbol_diagnostics
     }
+    pub fn get_dependency_context_diagnostics(&self) -> bool {
+        self.dependency_context_diagnostics
+    }
     pub fn is_verbose(&self) -> bool {
         self.trace.is_verbose()
     }
@@ -357,6 +366,8 @@ impl Default for ServerConfig {
             path_remapping: HashMap::new(),
             validate: ServerConfig::DEFAULT_VALIDATE,
             symbols: ServerConfig::DEFAULT_SYMBOLS,
+            dependency_context_diagnostics:
+                ServerConfig::DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS,
             experimental_macro_expansion: false,
             stage_define: HashMap::new(),
             symbol_diagnostics: ServerConfig::DEFAULT_SYMBOL_DIAGNOSTIC,
@@ -500,6 +511,8 @@ mod tests {
         assert!(cfg.get_symbols() == ServerConfig::DEFAULT_SYMBOLS);
         assert!(cfg.get_validate() == ServerConfig::DEFAULT_VALIDATE);
         assert!(cfg.get_symbol_diagnostics() == ServerConfig::DEFAULT_SYMBOL_DIAGNOSTIC);
+        assert!(cfg.get_dependency_context_diagnostics()
+            == ServerConfig::DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS);
         assert!(cfg.is_verbose() == ServerConfig::DEFAULT_TRACE.is_verbose());
         assert!(cfg.get_severity() == ServerConfig::DEFAULT_SEVERITY);
     }

--- a/shader-language-server/src/server/server_config.rs
+++ b/shader-language-server/src/server/server_config.rs
@@ -93,7 +93,7 @@ pub struct ServerSerializedConfig {
     symbols: Option<bool>,                    // Query symbols
     symbol_diagnostics: Option<bool>,         // Debug option to visualise issues with tree-sitter
     dependency_context_diagnostics: Option<bool>, // Reuse a dependent main-file context for document diagnostics.
-    experimental_macro_expansion: Option<bool>, // Experimental test for the new feature.
+    experimental_macro_expansion: Option<bool>,   // Experimental test for the new feature.
     stage_define: Option<HashMap<ShaderStage, HashMap<String, String>>>, // Specific macro defined per shader stage
     trace: Option<ServerTrace>,      // Level of error to display
     severity: Option<String>,        // Severity of diagnostic to display
@@ -366,8 +366,7 @@ impl Default for ServerConfig {
             path_remapping: HashMap::new(),
             validate: ServerConfig::DEFAULT_VALIDATE,
             symbols: ServerConfig::DEFAULT_SYMBOLS,
-            dependency_context_diagnostics:
-                ServerConfig::DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS,
+            dependency_context_diagnostics: ServerConfig::DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS,
             experimental_macro_expansion: false,
             stage_define: HashMap::new(),
             symbol_diagnostics: ServerConfig::DEFAULT_SYMBOL_DIAGNOSTIC,
@@ -511,8 +510,10 @@ mod tests {
         assert!(cfg.get_symbols() == ServerConfig::DEFAULT_SYMBOLS);
         assert!(cfg.get_validate() == ServerConfig::DEFAULT_VALIDATE);
         assert!(cfg.get_symbol_diagnostics() == ServerConfig::DEFAULT_SYMBOL_DIAGNOSTIC);
-        assert!(cfg.get_dependency_context_diagnostics()
-            == ServerConfig::DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS);
+        assert!(
+            cfg.get_dependency_context_diagnostics()
+                == ServerConfig::DEFAULT_DEPENDENCY_CONTEXT_DIAGNOSTICS
+        );
         assert!(cfg.is_verbose() == ServerConfig::DEFAULT_TRACE.is_verbose());
         assert!(cfg.get_severity() == ServerConfig::DEFAULT_SEVERITY);
     }

--- a/shader-language-server/src/server/server_file_cache.rs
+++ b/shader-language-server/src/server/server_file_cache.rs
@@ -107,6 +107,22 @@ impl ServerLanguageFileCache {
             .map(|(url, _file)| url.clone())
             .collect()
     }
+    pub fn get_primary_dependent_main_file(&self, dependent_url: &Url) -> Option<Url> {
+        let mut dependent_files: Vec<_> = self
+            .get_dependent_main_files(dependent_url)
+            .into_iter()
+            .collect();
+        dependent_files.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        dependent_files.into_iter().next()
+    }
+    pub fn get_document_diagnostic_context(&self, uri: &Url) -> Url {
+        match self.files.get(uri) {
+            Some(file) if file.shading_language == ShadingLanguage::Glsl => self
+                .get_primary_dependent_main_file(uri)
+                .unwrap_or_else(|| uri.clone()),
+            _ => uri.clone(),
+        }
+    }
     // Get all main files relying on the given file.
     #[allow(dead_code)]
     pub fn get_relying_main_files(&self, url: &Url) -> HashSet<Url> {

--- a/shader-language-server/src/server/server_file_cache.rs
+++ b/shader-language-server/src/server/server_file_cache.rs
@@ -115,13 +115,20 @@ impl ServerLanguageFileCache {
         dependent_files.sort_by(|left, right| left.as_str().cmp(right.as_str()));
         dependent_files.into_iter().next()
     }
+    fn supports_automatic_dependency_diagnostic_context(&self, uri: &Url) -> bool {
+        matches!(
+            self.files.get(uri),
+            Some(file) if file.shading_language == ShadingLanguage::Glsl
+        )
+    }
     pub fn get_document_diagnostic_context(&self, uri: &Url) -> Url {
-        match self.files.get(uri) {
-            Some(file) if file.shading_language == ShadingLanguage::Glsl => self
-                .get_primary_dependent_main_file(uri)
-                .unwrap_or_else(|| uri.clone()),
-            _ => uri.clone(),
+        if self.get_relying_variant(uri).is_some()
+            || !self.supports_automatic_dependency_diagnostic_context(uri)
+        {
+            return uri.clone();
         }
+        self.get_primary_dependent_main_file(uri)
+            .unwrap_or_else(|| uri.clone())
     }
     // Get all main files relying on the given file.
     #[allow(dead_code)]

--- a/shader-language-server/tests/glsl_dependency_diagnostics.rs
+++ b/shader-language-server/tests/glsl_dependency_diagnostics.rs
@@ -2,14 +2,19 @@
 // WASI cannot spawn a server so test on pc with WASMTIME runner instead.
 #![cfg(not(target_os = "wasi"))]
 
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 use lsp_types::request::DocumentDiagnosticRequest;
 use lsp_types::{
-    notification::{DidCloseTextDocument, DidOpenTextDocument},
+    notification::{DidChangeConfiguration, DidCloseTextDocument, DidOpenTextDocument},
     DiagnosticSeverity, DocumentDiagnosticParams, DocumentDiagnosticReport,
-    DocumentDiagnosticReportResult, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    PartialResultParams, RelatedFullDocumentDiagnosticReport, WorkDoneProgressParams,
+    DocumentDiagnosticReportResult, DidChangeConfigurationParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, PartialResultParams, RelatedFullDocumentDiagnosticReport,
+    WorkDoneProgressParams,
+};
+use serde_json::{json, Value};
+use shader_language_server::server::shader_variant::{
+    DidChangeShaderVariant, DidChangeShaderVariantParams, ShaderVariant,
 };
 use shader_sense::shader::ShadingLanguage;
 use test_server::{TestFile, TestServer};
@@ -28,6 +33,15 @@ fn get_diagnostic_report(
     } else {
         unreachable!("Should not be reached");
     }
+}
+
+fn enable_dependency_context_diagnostics(server: &mut TestServer) {
+    server.set_workspace_configuration_response(vec![json!({
+        "dependencyContextDiagnostics": true,
+    })]);
+    server.send_notification::<DidChangeConfiguration>(&DidChangeConfigurationParams {
+        settings: Value::Null,
+    });
 }
 
 #[test]
@@ -69,6 +83,33 @@ fn test_glsl_dependency_document_diagnostics_use_includer_context() {
                 })
                 .collect();
             assert!(
+                !errors.is_empty(),
+                "Dependency-context diagnostics should stay disabled by default. Got {:#?}",
+                errors,
+            );
+        },
+    );
+    enable_dependency_context_diagnostics(&mut server);
+    server.send_request::<DocumentDiagnosticRequest>(
+        &DocumentDiagnosticParams {
+            text_document: deps.identifier(),
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+        |report| {
+            let report = get_diagnostic_report(report.unwrap());
+            let errors: Vec<&lsp_types::Diagnostic> = report
+                .full_document_diagnostic_report
+                .items
+                .iter()
+                .filter(|d| match &d.severity {
+                    Some(severity) => *severity == DiagnosticSeverity::ERROR,
+                    None => false,
+                })
+                .collect();
+            assert!(
                 errors.is_empty(),
                 "Include file should inherit diagnostics context from its main shader. Got {:#?}",
                 errors,
@@ -80,5 +121,82 @@ fn test_glsl_dependency_document_diagnostics_use_includer_context() {
     });
     server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
         text_document: file.identifier(),
+    });
+}
+
+#[test]
+fn test_glsl_dependency_document_diagnostics_keep_selected_variant_context() {
+    let mut server = TestServer::desktop().unwrap();
+    enable_dependency_context_diagnostics(&mut server);
+
+    let invalid_main = TestFile::new(
+        Path::new("../shader-sense/test/glsl/a-include-context.frag.glsl"),
+        ShadingLanguage::Glsl,
+    );
+    let selected_variant = TestFile::new(
+        Path::new("../shader-sense/test/glsl/include-context.comp.glsl"),
+        ShadingLanguage::Glsl,
+    );
+    let deps = TestFile::new(
+        Path::new("../shader-sense/test/glsl/workgroup-layout.glsl"),
+        ShadingLanguage::Glsl,
+    );
+
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: invalid_main.item(),
+    });
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: selected_variant.item(),
+    });
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: deps.item(),
+    });
+    server.send_notification::<DidChangeShaderVariant>(&DidChangeShaderVariantParams {
+        shader_variant: Some(ShaderVariant {
+            url: selected_variant.url.clone(),
+            shading_language: ShadingLanguage::Glsl,
+            entry_point: "".into(),
+            stage: None,
+            defines: HashMap::new(),
+            includes: Vec::new(),
+        }),
+    });
+    server.send_request::<DocumentDiagnosticRequest>(
+        &DocumentDiagnosticParams {
+            text_document: deps.identifier(),
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+        |report| {
+            let report = get_diagnostic_report(report.unwrap());
+            let errors: Vec<&lsp_types::Diagnostic> = report
+                .full_document_diagnostic_report
+                .items
+                .iter()
+                .filter(|d| match &d.severity {
+                    Some(severity) => *severity == DiagnosticSeverity::ERROR,
+                    None => false,
+                })
+                .collect();
+            assert!(
+                errors.is_empty(),
+                "Selected variant should take precedence over auto-selected includers. Got {:#?}",
+                errors,
+            );
+        },
+    );
+    server.send_notification::<DidChangeShaderVariant>(&DidChangeShaderVariantParams {
+        shader_variant: None,
+    });
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: deps.identifier(),
+    });
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: selected_variant.identifier(),
+    });
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: invalid_main.identifier(),
     });
 }

--- a/shader-language-server/tests/glsl_dependency_diagnostics.rs
+++ b/shader-language-server/tests/glsl_dependency_diagnostics.rs
@@ -1,0 +1,84 @@
+// Skip all these test on WASI.
+// WASI cannot spawn a server so test on pc with WASMTIME runner instead.
+#![cfg(not(target_os = "wasi"))]
+
+use std::path::Path;
+
+use lsp_types::request::DocumentDiagnosticRequest;
+use lsp_types::{
+    notification::{DidCloseTextDocument, DidOpenTextDocument},
+    DiagnosticSeverity, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentDiagnosticReportResult, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    PartialResultParams, RelatedFullDocumentDiagnosticReport, WorkDoneProgressParams,
+};
+use shader_sense::shader::ShadingLanguage;
+use test_server::{TestFile, TestServer};
+
+mod test_server;
+
+fn get_diagnostic_report(
+    result: DocumentDiagnosticReportResult,
+) -> RelatedFullDocumentDiagnosticReport {
+    if let DocumentDiagnosticReportResult::Report(report) = result {
+        if let DocumentDiagnosticReport::Full(report) = report {
+            report
+        } else {
+            unreachable!("Should not be reached");
+        }
+    } else {
+        unreachable!("Should not be reached");
+    }
+}
+
+#[test]
+fn test_glsl_dependency_document_diagnostics_use_includer_context() {
+    let mut server = TestServer::desktop().unwrap();
+
+    let file = TestFile::new(
+        Path::new("../shader-sense/test/glsl/include-context.comp.glsl"),
+        ShadingLanguage::Glsl,
+    );
+    let deps = TestFile::new(
+        Path::new("../shader-sense/test/glsl/workgroup-layout.glsl"),
+        ShadingLanguage::Glsl,
+    );
+
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: file.item(),
+    });
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: deps.item(),
+    });
+    server.send_request::<DocumentDiagnosticRequest>(
+        &DocumentDiagnosticParams {
+            text_document: deps.identifier(),
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+        |report| {
+            let report = get_diagnostic_report(report.unwrap());
+            let errors: Vec<&lsp_types::Diagnostic> = report
+                .full_document_diagnostic_report
+                .items
+                .iter()
+                .filter(|d| match &d.severity {
+                    Some(severity) => *severity == DiagnosticSeverity::ERROR,
+                    None => false,
+                })
+                .collect();
+            assert!(
+                errors.is_empty(),
+                "Include file should inherit diagnostics context from its main shader. Got {:#?}",
+                errors,
+            );
+        },
+    );
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: deps.identifier(),
+    });
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: file.identifier(),
+    });
+}

--- a/shader-language-server/tests/glsl_dependency_diagnostics.rs
+++ b/shader-language-server/tests/glsl_dependency_diagnostics.rs
@@ -7,9 +7,9 @@ use std::{collections::HashMap, path::Path};
 use lsp_types::request::DocumentDiagnosticRequest;
 use lsp_types::{
     notification::{DidChangeConfiguration, DidCloseTextDocument, DidOpenTextDocument},
-    DiagnosticSeverity, DocumentDiagnosticParams, DocumentDiagnosticReport,
-    DocumentDiagnosticReportResult, DidChangeConfigurationParams, DidCloseTextDocumentParams,
-    DidOpenTextDocumentParams, PartialResultParams, RelatedFullDocumentDiagnosticReport,
+    DiagnosticSeverity, DidChangeConfigurationParams, DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentDiagnosticReportResult, PartialResultParams, RelatedFullDocumentDiagnosticReport,
     WorkDoneProgressParams,
 };
 use serde_json::{json, Value};

--- a/shader-language-server/tests/test_server.rs
+++ b/shader-language-server/tests/test_server.rs
@@ -62,6 +62,7 @@ pub struct TestServer {
     reader: BufReader<ChildStdout>,
     err_reader: BufReader<ChildStderr>,
     request_id: i32,
+    workspace_configuration_response: Vec<Value>,
     notification_handler: HashMap<&'static str, Box<dyn FnMut(Value)>>,
 }
 impl TestServer {
@@ -142,6 +143,7 @@ impl TestServer {
             reader,
             err_reader,
             stdin,
+            workspace_configuration_response: vec![Value::Null],
             notification_handler: HashMap::new(),
         };
         // Send an LSP initialize request
@@ -277,8 +279,10 @@ impl TestServer {
     }
     fn on_request(&mut self, request: lsp_server::Request) {
         match request.method.as_str() {
-            WorkspaceConfiguration::METHOD => self
-                .send_response::<WorkspaceConfiguration>(request.id, vec![serde_json::Value::Null]),
+            WorkspaceConfiguration::METHOD => self.send_response::<WorkspaceConfiguration>(
+                request.id,
+                self.workspace_configuration_response.clone(),
+            ),
             WorkDoneProgressCreate::METHOD => {
                 self.send_response::<WorkDoneProgressCreate>(request.id, ())
             }
@@ -286,6 +290,10 @@ impl TestServer {
                 panic!("Unhandled request {}", request.method);
             }
         }
+    }
+    #[allow(dead_code)]
+    pub fn set_workspace_configuration_response(&mut self, response: Vec<Value>) {
+        self.workspace_configuration_response = response;
     }
     #[allow(dead_code)]
     pub fn subsbscribe<T: lsp_types::notification::Notification, F: FnMut(Value) + 'static>(

--- a/shader-sense/test/glsl/a-include-context.frag.glsl
+++ b/shader-sense/test/glsl/a-include-context.frag.glsl
@@ -1,0 +1,11 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "./workgroup-layout.glsl"
+
+layout(location = 0) out vec4 outColor;
+
+void main() {
+    outColor = vec4(1.0);
+}

--- a/shader-sense/test/glsl/include-context.comp.glsl
+++ b/shader-sense/test/glsl/include-context.comp.glsl
@@ -1,0 +1,7 @@
+#version 450
+
+#extension GL_GOOGLE_include_directive : require
+
+#include "./workgroup-layout.glsl"
+
+void main() {}

--- a/shader-sense/test/glsl/workgroup-layout.glsl
+++ b/shader-sense/test/glsl/workgroup-layout.glsl
@@ -1,0 +1,1 @@
+layout(local_size_x = 8, local_size_y = 4, local_size_z = 1) in;


### PR DESCRIPTION
This fixes false diagnostics for GLSL include/header files by resolving document diagnostics in the includer's context instead of treating them as standalone shader files.

Those GLSL module files being used as "#include" can be opened and diagnosed on their own, but their contents are only valid in the context of a main shader. 
Without using the includer's context, the language server reports spurious errors for included-only files.There is one trick to avoid it that using comment like"//#version 460" in released version,but non-native.

Changed:
- resolve GLSL dependency diagnostics through the primary dependent main file
- keep HLSL and WGSL behavior unchanged
- move the regression coverage into a standalone GLSL integration test
- add a dedicated includer-context fixture glsl file

Validation:
- `cargo test -p shader_language_server test_glsl_dependency_document_diagnostics_use_includer_context -- --nocapture`
- `cargo test -p shader_language_server test_variant_dependency -- --nocapture`