### PR TITLE
Add compilation request to get back result of shader compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,9 @@ jobs:
         run: |
           wget https://wasmtime.dev/install.sh 
           chmod +x ./install.sh
-          sudo ./install.sh --version v46.0.3
+          ./install.sh --version v46.0.3
           source ~/.bashrc
+          wasmtime --version
       - name: Test WASI # Test only server & main library on WASI. Skip doc test as they are already done and somehow get OOM.
         run: cargo test --package shader_language_server --package shader-sense --all-targets --target wasm32-wasip1-threads -- --nocapture
         env: # Somehow this VM has clang14 by default, which is not supported...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,8 @@ jobs:
               clang-17 --version
       - name: Add target
         run: rustup target add wasm32-wasip1-threads
-      - name: Install wasmtime as test runner.
-        run: curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.3
+      - name: Install wasmtime as test runner and reload env.
+        run: curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.3 | source ~/.bashrc
       - name: Test WASI # Test only server & main library on WASI. Skip doc test as they are already done and somehow get OOM.
         run: cargo test --package shader_language_server --package shader-sense --all-targets --target wasm32-wasip1-threads -- --nocapture
         env: # Somehow this VM has clang14 by default, which is not supported...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,6 @@ jobs:
           chmod +x ./install.sh
           sudo ./install.sh --version v46.0.3
           source ~/.bashrc
-          wasmtime --version
       - name: Test WASI # Test only server & main library on WASI. Skip doc test as they are already done and somehow get OOM.
         run: cargo test --package shader_language_server --package shader-sense --all-targets --target wasm32-wasip1-threads -- --nocapture
         env: # Somehow this VM has clang14 by default, which is not supported...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,8 @@ jobs:
               clang-17 --version
       - name: Add target
         run: rustup target add wasm32-wasip1-threads
-      - name: Install wasmtime as test runner and reload env.
-        run: curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.3 | source ~/.bashrc
+      - name: Install wasmtime as test runner.
+        run: curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.3 | bash
       - name: Test WASI # Test only server & main library on WASI. Skip doc test as they are already done and somehow get OOM.
         run: cargo test --package shader_language_server --package shader-sense --all-targets --target wasm32-wasip1-threads -- --nocapture
         env: # Somehow this VM has clang14 by default, which is not supported...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,12 +110,16 @@ jobs:
       - name: Add target
         run: rustup target add wasm32-wasip1-threads
       - name: Install wasmtime as test runner.
+        # The installer appends the PATH export to ~/.bashrc, but Actions steps run in a
+        # non-interactive bash which bails out at the top of ~/.bashrc, and PATH would not
+        # persist to the next step anyway. So export it through $GITHUB_PATH instead.
         run: |
-          wget https://wasmtime.dev/install.sh 
+          wget https://wasmtime.dev/install.sh
           chmod +x ./install.sh
           ./install.sh --version v46.0.3
-          source ~/.bashrc
-          wasmtime --version
+          echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
+      - name: Check wasmtime version
+        run: wasmtime --version
       - name: Test WASI # Test only server & main library on WASI. Skip doc test as they are already done and somehow get OOM.
         run: cargo test --package shader_language_server --package shader-sense --all-targets --target wasm32-wasip1-threads -- --nocapture
         env: # Somehow this VM has clang14 by default, which is not supported...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,12 @@ jobs:
       - name: Add target
         run: rustup target add wasm32-wasip1-threads
       - name: Install wasmtime as test runner.
-        run: curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.3 | bash
+        run: |
+          wget https://wasmtime.dev/install.sh 
+          chmod +x ./install.sh
+          sudo ./install.sh --version v46.0.3
+          source ~/.bashrc
+          wasmtime --version
       - name: Test WASI # Test only server & main library on WASI. Skip doc test as they are already done and somehow get OOM.
         run: cargo test --package shader_language_server --package shader-sense --all-targets --target wasm32-wasip1-threads -- --nocapture
         env: # Somehow this VM has clang14 by default, which is not supported...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Add target
         run: rustup target add wasm32-wasip1-threads
       - name: Install wasmtime as test runner.
-        run: curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version 46.0.3
+        run: curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v46.0.3
       - name: Test WASI # Test only server & main library on WASI. Skip doc test as they are already done and somehow get OOM.
         run: cargo test --package shader_language_server --package shader-sense --all-targets --target wasm32-wasip1-threads -- --nocapture
         env: # Somehow this VM has clang14 by default, which is not supported...

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +792,9 @@ dependencies = [
  "hexf-parse",
  "indexmap",
  "log",
+ "petgraph",
  "rustc-hash 1.1.0",
+ "spirv",
  "strum",
  "termcolor",
  "thiserror 2.0.12",
@@ -839,6 +847,16 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
@@ -1318,6 +1336,15 @@ dependencies = [
  "autocfg",
  "static_assertions",
  "version_check",
+]
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-bytes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce54e4e485fa0eed9c3aa5348162be09168f75bb5be7bc6587bcf2a65ee1386"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1271,7 @@ dependencies = [
 name = "shader_language_server"
 version = "1.4.3"
 dependencies = [
+ "base64-bytes",
  "cfg-if",
  "crossbeam-channel",
  "env_logger",

--- a/shader-language-server/Cargo.toml
+++ b/shader-language-server/Cargo.toml
@@ -27,3 +27,4 @@ lsp-server = "=0.7.8" # 0.7.9 has some breaking changes.
 lsp-types = "0.95.0"
 crossbeam-channel = "0.5.8"
 lru = "0.16.0"
+base64-bytes = "0.1.0"

--- a/shader-language-server/README.md
+++ b/shader-language-server/README.md
@@ -141,10 +141,11 @@ As this server has everything in its hand to compile a shader, we can simply get
 ```typescript
 interface CompilationRequestParams {
     uri: string
+    compilationType: 'Spirv' | 'Dxil' | 'Wgsl' | null, // Optionnal type to convert the .
 }
+// Might be null if compilation failed. Check diagnostics
 interface CompilationRequestResult {
-    // The requested file might require to be a variant
-    ty: 'Spirv' | 'Dxil' | 'None', // If None, compilation probably failed. Check diagnostics.
+    compilationType: 'Spirv' | 'Dxil' | 'Wgsl',
     data: string // The result of the compilation as a base64 encoded byte array.
 }
 ```

--- a/shader-language-server/README.md
+++ b/shader-language-server/README.md
@@ -134,6 +134,21 @@ interface ShaderVariant {
 }
 ```
 
+### Compilation commands
+
+As this server has everything in its hand to compile a shader, we can simply get the resulting binary via a custom request. Use request `textDocument/compilationResult` to get the compilation result as binary.
+
+```typescript
+interface CompilationRequestParams {
+    uri: string
+}
+interface CompilationRequestResult {
+    // The requested file might require to be a variant
+    ty: 'Spirv' | 'Dxil' | 'None', // If None, compilation probably failed. Check diagnostics.
+    data: Uint8Array // The result of the compilation.
+}
+```
+
 ### Debug commands:
 
 The server offer some specific debug request to help inspect the current state of the server.

--- a/shader-language-server/README.md
+++ b/shader-language-server/README.md
@@ -141,7 +141,7 @@ As this server has everything in its hand to compile a shader, we can simply get
 ```typescript
 interface CompilationRequestParams {
     uri: string
-    compilationType: 'Spirv' | 'Dxil' | 'Wgsl' | null, // Optionnal type to convert the .
+    compilationType: 'Spirv' | 'Dxil' | 'Wgsl' | null, // Optionnal type to convert the compilation result.
 }
 // Might be null if compilation failed. Check diagnostics
 interface CompilationRequestResult {

--- a/shader-language-server/README.md
+++ b/shader-language-server/README.md
@@ -145,7 +145,7 @@ interface CompilationRequestParams {
 interface CompilationRequestResult {
     // The requested file might require to be a variant
     ty: 'Spirv' | 'Dxil' | 'None', // If None, compilation probably failed. Check diagnostics.
-    data: Uint8Array // The result of the compilation.
+    data: string // The result of the compilation as a base64 encoded byte array.
 }
 ```
 

--- a/shader-language-server/src/server.rs
+++ b/shader-language-server/src/server.rs
@@ -458,8 +458,10 @@ impl ServerLanguage {
                     async_request.params.text_document.uri,
                     self.debug(&async_request.params)
                 );
-                let compilation_request_result =
-                    self.recolt_compilation_result(&async_request.params.text_document.uri)?;
+                let compilation_request_result = self.recolt_compilation_result(
+                    &async_request.params.text_document.uri,
+                    async_request.params.compilation_type,
+                )?;
                 self.connection.send_response::<CompilationRequest>(
                     async_request.req_id.clone(),
                     compilation_request_result,

--- a/shader-language-server/src/server.rs
+++ b/shader-language-server/src/server.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 mod async_message;
 mod common;
 mod debug;
-mod provider;
+pub mod provider; // pub for test
 pub mod shader_variant; // pub for test.
 
 mod profile;
@@ -60,6 +60,7 @@ use shader_variant::DidChangeShaderVariant;
 use crate::profile_scope;
 use crate::server::async_message::{AsyncCacheRequest, AsyncMessage, AsyncRequest};
 use crate::server::common::{lsp_range_to_shader_range, ServerLanguageError};
+use crate::server::provider::compilation::CompilationRequest;
 use crate::server::server_config::{ServerTrace, ServerTraceLevel};
 use crate::server::server_file_cache::ServerFileCache;
 
@@ -451,6 +452,19 @@ impl ServerLanguage {
                     Some(semantic_tokens),
                 );
             }
+            AsyncMessage::CompilationRequest(async_request) => {
+                profile_scope!(
+                    "Received compilation request for file {}: {}",
+                    async_request.params.text_document.uri,
+                    self.debug(&async_request.params)
+                );
+                let compilation_request_result =
+                    self.recolt_compilation_result(&async_request.params.text_document.uri)?;
+                self.connection.send_response::<CompilationRequest>(
+                    async_request.req_id.clone(),
+                    compilation_request_result,
+                );
+            }
             AsyncMessage::DumpDependencyRequest(async_request) => {
                 profile_scope!(
                     "Received dump dependency request for file {}: {}",
@@ -809,6 +823,10 @@ impl ServerLanguage {
                 DumpDependencyRequest::METHOD => AsyncMessage::DumpDependencyRequest(
                     AsyncRequest::new(req.id, serde_json::from_value(req.params)?),
                 ),
+                CompilationRequest::METHOD => AsyncMessage::CompilationRequest(AsyncRequest::new(
+                    req.id,
+                    serde_json::from_value(req.params)?,
+                )),
                 _ => {
                     warn!("Received unhandled request: {:#?}", req);
                     return Err(ServerLanguageError::MethodNotFound(req.method));

--- a/shader-language-server/src/server/async_message.rs
+++ b/shader-language-server/src/server/async_message.rs
@@ -15,6 +15,7 @@ use shader_sense::shader::ShadingLanguage;
 use crate::server::{
     clean_url,
     debug::{DumpAstParams, DumpAstRequest, DumpDependencyParams, DumpDependencyRequest},
+    provider::compilation::{CompilationRequest, CompilationRequestParams},
 };
 
 pub struct AsyncRequest<R: Request> {
@@ -47,6 +48,7 @@ pub enum AsyncMessage {
     Completion(AsyncRequest<Completion>),
     GotoDefinition(AsyncRequest<GotoDefinition>),
     DocumentDiagnosticRequest(AsyncRequest<DocumentDiagnosticRequest>),
+    CompilationRequest(AsyncRequest<CompilationRequest>),
     // Debug
     DumpDependencyRequest(AsyncRequest<DumpDependencyRequest>),
     DumpAstRequest(AsyncRequest<DumpAstRequest>),
@@ -84,6 +86,7 @@ impl AsyncMessage {
             AsyncMessage::Completion(async_request) => &async_request.req_id,
             AsyncMessage::GotoDefinition(async_request) => &async_request.req_id,
             AsyncMessage::DocumentDiagnosticRequest(async_request) => &async_request.req_id,
+            AsyncMessage::CompilationRequest(async_request) => &async_request.req_id,
             AsyncMessage::DumpDependencyRequest(async_request) => &async_request.req_id,
             AsyncMessage::DumpAstRequest(async_request) => &async_request.req_id,
             // These variants do not have a RequestId
@@ -107,6 +110,7 @@ impl AsyncMessage {
             AsyncMessage::Completion(_) => Completion::METHOD,
             AsyncMessage::GotoDefinition(_) => GotoDefinition::METHOD,
             AsyncMessage::DocumentDiagnosticRequest(_) => DocumentDiagnosticRequest::METHOD,
+            AsyncMessage::CompilationRequest(_) => CompilationRequest::METHOD,
             AsyncMessage::DumpDependencyRequest(_) => DumpDependencyRequest::METHOD,
             AsyncMessage::DumpAstRequest(_) => DumpAstRequest::METHOD,
             // These variants do not have a method
@@ -170,6 +174,9 @@ impl AsyncMessage {
                 Some(&async_request.params.text_document.uri)
             }
             AsyncMessage::DumpAstRequest(async_request) => {
+                Some(&async_request.params.text_document.uri)
+            }
+            AsyncMessage::CompilationRequest(async_request) => {
                 Some(&async_request.params.text_document.uri)
             }
             // These variants do not have a uri
@@ -253,6 +260,11 @@ impl ParamsDeserialization for GotoDefinitionParams {
     }
 }
 impl ParamsDeserialization for DocumentDiagnosticParams {
+    fn clean(&mut self) {
+        self.text_document.uri = clean_url(&self.text_document.uri)
+    }
+}
+impl ParamsDeserialization for CompilationRequestParams {
     fn clean(&mut self) {
         self.text_document.uri = clean_url(&self.text_document.uri)
     }

--- a/shader-language-server/src/server/provider/compilation.rs
+++ b/shader-language-server/src/server/provider/compilation.rs
@@ -29,7 +29,6 @@ pub struct CompilationRequestParams {
 pub enum CompilationType {
     Spirv,
     Dxil,
-    None,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
@@ -53,18 +52,22 @@ impl ServerLanguage {
         let cached_file = self.get_cachable_file(&uri)?;
 
         if let Some(data) = &cached_file.data {
-            Ok(Some(CompilationRequestResult {
-                ty: match &data.compilation_cache {
-                    CompilationResult::None => CompilationType::None,
-                    CompilationResult::Dxil(_) => CompilationType::Dxil,
-                    CompilationResult::Spirv(_) => CompilationType::Spirv,
-                },
-                data: match &data.compilation_cache {
-                    CompilationResult::None => Vec::new(),
-                    CompilationResult::Dxil(dxil) => dxil.clone(),
-                    CompilationResult::Spirv(spirv) => spirv.clone(),
-                },
-            }))
+            if let CompilationResult::None = data.compilation_cache {
+                Ok(None)
+            } else {
+                Ok(Some(CompilationRequestResult {
+                    ty: match &data.compilation_cache {
+                        CompilationResult::None => unreachable!(),
+                        CompilationResult::Dxil(_) => CompilationType::Dxil,
+                        CompilationResult::Spirv(_) => CompilationType::Spirv,
+                    },
+                    data: match &data.compilation_cache {
+                        CompilationResult::None => Vec::new(),
+                        CompilationResult::Dxil(dxil) => dxil.clone(),
+                        CompilationResult::Spirv(spirv) => spirv.clone(),
+                    },
+                }))
+            }
         } else {
             Ok(None)
         }

--- a/shader-language-server/src/server/provider/compilation.rs
+++ b/shader-language-server/src/server/provider/compilation.rs
@@ -35,6 +35,7 @@ pub enum CompilationType {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct CompilationRequestResult {
     pub ty: CompilationType,
+    #[serde(with = "base64_bytes")] // Compress the data
     pub data: Vec<u8>,
 }
 

--- a/shader-language-server/src/server/provider/compilation.rs
+++ b/shader-language-server/src/server/provider/compilation.rs
@@ -1,8 +1,13 @@
 use lsp_types::{request::Request, TextDocumentIdentifier, Url};
 use serde::{Deserialize, Serialize};
-use shader_sense::validator::validator::CompilationResult;
+use shader_sense::{
+    shader::ShadingLanguage,
+    validator::{naga::Naga, validator::CompilationResult},
+};
 
-use crate::server::{common::ServerLanguageError, ServerLanguage};
+use crate::server::{
+    common::ServerLanguageError, server_file_cache::ServerFileCache, ServerLanguage,
+};
 
 /// Custom LSP request (client -> server), method `textDocument/compilationResult`.
 ///
@@ -23,17 +28,19 @@ pub enum CompilationRequest {}
 pub struct CompilationRequestParams {
     #[serde(flatten)]
     pub text_document: TextDocumentIdentifier,
+    pub compilation_type: Option<CompilationType>, // requested compilation type
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub enum CompilationType {
     Spirv,
     Dxil,
+    Wgsl, // Wgsl used as is
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct CompilationRequestResult {
-    pub ty: CompilationType,
+    pub compilation_type: CompilationType,
     #[serde(with = "base64_bytes")] // Compress the data
     pub data: Vec<u8>,
 }
@@ -48,28 +55,119 @@ impl ServerLanguage {
     pub fn recolt_compilation_result(
         &self,
         uri: &Url,
+        compilation_type: Option<CompilationType>,
     ) -> Result<Option<CompilationRequestResult>, ServerLanguageError> {
         let cached_file = self.get_cachable_file(&uri)?;
-
-        if let Some(data) = &cached_file.data {
-            if let CompilationResult::None = data.compilation_cache {
-                Ok(None)
+        fn get_cached_result(cached_file: &ServerFileCache) -> Option<CompilationRequestResult> {
+            if let Some(data) = &cached_file.data {
+                if let CompilationResult::None = data.compilation_cache {
+                    None
+                } else {
+                    Some(CompilationRequestResult {
+                        compilation_type: match &data.compilation_cache {
+                            CompilationResult::None => unreachable!(),
+                            CompilationResult::Dxil(_) => CompilationType::Dxil,
+                            CompilationResult::Spirv(_) => CompilationType::Spirv,
+                            CompilationResult::Wgsl(_) => CompilationType::Wgsl,
+                        },
+                        data: match &data.compilation_cache {
+                            CompilationResult::None => Vec::new(),
+                            CompilationResult::Dxil(dxil) => dxil.clone(),
+                            CompilationResult::Spirv(spirv) => spirv.clone(),
+                            CompilationResult::Wgsl(wgsl) => wgsl.clone().into_bytes(),
+                        },
+                    })
+                }
             } else {
-                Ok(Some(CompilationRequestResult {
-                    ty: match &data.compilation_cache {
-                        CompilationResult::None => unreachable!(),
-                        CompilationResult::Dxil(_) => CompilationType::Dxil,
-                        CompilationResult::Spirv(_) => CompilationType::Spirv,
-                    },
-                    data: match &data.compilation_cache {
-                        CompilationResult::None => Vec::new(),
-                        CompilationResult::Dxil(dxil) => dxil.clone(),
-                        CompilationResult::Spirv(spirv) => spirv.clone(),
-                    },
-                }))
+                None
+            }
+        }
+        if let Some(compilation_type) = compilation_type {
+            let shading_language = cached_file.shading_language;
+            match compilation_type {
+                CompilationType::Spirv => match shading_language {
+                    ShadingLanguage::Glsl => {
+                        if self.config.is_generating_spirv(ShadingLanguage::Glsl) {
+                            Err(ServerLanguageError::InvalidParams(format!("Cannot request compilation to SPIRV for GLSL with no SPIRV version set.")))
+                        } else {
+                            Ok(get_cached_result(cached_file)) // Glsl already compile to SPIRV
+                        }
+                    }
+                    ShadingLanguage::Hlsl => {
+                        if self.config.is_generating_spirv(ShadingLanguage::Hlsl) {
+                            Ok(get_cached_result(cached_file)) // Hlsl generate spirv already
+                        } else {
+                            Err(ServerLanguageError::InvalidParams(format!("Cannot request SPIRV compilation for HLSL without enabling the spirv generation.")))
+                        }
+                    }
+                    ShadingLanguage::Wgsl => {
+                        if let Some(data) = &cached_file.data {
+                            if let CompilationResult::Wgsl(wgsl) = &data.compilation_cache {
+                                match Naga::wgsl_to_spirv(&wgsl) {
+                                    Ok(spirv) => Ok(Some(CompilationRequestResult {
+                                        compilation_type: CompilationType::Spirv,
+                                        data: spirv,
+                                    })),
+                                    Err(err) => Err(ServerLanguageError::ShaderError(err)),
+                                }
+                            } else {
+                                Err(ServerLanguageError::InternalError(format!(
+                                    "No Wgsl generated in cache."
+                                )))
+                            }
+                        } else {
+                            Err(ServerLanguageError::InternalError(format!(
+                                "No cache for file."
+                            )))
+                        }
+                    }
+                },
+                CompilationType::Dxil => match shading_language {
+                    ShadingLanguage::Hlsl => {
+                        if self.config.is_generating_spirv(ShadingLanguage::Hlsl) {
+                            Err(ServerLanguageError::InvalidParams(format!("Cannot request DXIL compilation for HLSL with spirv generation enabled.")))
+                        } else {
+                            Ok(get_cached_result(cached_file)) // HLSL generate DXIL already
+                        }
+                    }
+                    ShadingLanguage::Glsl | ShadingLanguage::Wgsl => {
+                        Err(ServerLanguageError::InvalidParams(format!(
+                            "Cannot request compilation to Dxil for {:?}",
+                            shading_language
+                        )))
+                    }
+                },
+                CompilationType::Wgsl => match shading_language {
+                    ShadingLanguage::Glsl | ShadingLanguage::Hlsl => {
+                        if self.config.is_generating_spirv(shading_language) {
+                            if let Some(data) = &cached_file.data {
+                                if let CompilationResult::Spirv(spirv) = &data.compilation_cache {
+                                    match Naga::spirv_to_wgsl(&spirv) {
+                                        Ok(wgsl) => Ok(Some(CompilationRequestResult {
+                                            compilation_type: CompilationType::Wgsl,
+                                            data: wgsl.into_bytes(),
+                                        })),
+                                        Err(err) => Err(ServerLanguageError::ShaderError(err)),
+                                    }
+                                } else {
+                                    Err(ServerLanguageError::InternalError(format!(
+                                        "No SPIRV generated in cache."
+                                    )))
+                                }
+                            } else {
+                                Err(ServerLanguageError::InternalError(format!(
+                                    "No cache for file."
+                                )))
+                            }
+                        } else {
+                            Err(ServerLanguageError::InvalidParams(format!("Cannot request compilation to WGSL for {:?} when not generating SPIRV.", shading_language)))
+                        }
+                    }
+                    ShadingLanguage::Wgsl => Ok(get_cached_result(cached_file)), // No cross compilation required
+                },
             }
         } else {
-            Ok(None)
+            Ok(get_cached_result(cached_file))
         }
     }
 }

--- a/shader-language-server/src/server/provider/compilation.rs
+++ b/shader-language-server/src/server/provider/compilation.rs
@@ -39,6 +39,7 @@ pub enum CompilationType {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompilationRequestResult {
     pub compilation_type: CompilationType,
     #[serde(with = "base64_bytes")] // Compress the data

--- a/shader-language-server/src/server/provider/compilation.rs
+++ b/shader-language-server/src/server/provider/compilation.rs
@@ -1,0 +1,71 @@
+use lsp_types::{request::Request, TextDocumentIdentifier, Url};
+use serde::{Deserialize, Serialize};
+use shader_sense::validator::validator::CompilationResult;
+
+use crate::server::{common::ServerLanguageError, ServerLanguage};
+
+/// Custom LSP request (client -> server), method `textDocument/compilationResult`.
+///
+/// This is not part of standard LSP. If you are implementing a client, send this request
+/// to ask the server for compilation result of given shader.
+///
+/// To implement it on the client side:
+/// - Use the exact method string `textDocument/compilationResult` (see `METHOD` below).
+/// - Send the JSON payload described by `CompilationRequestParams`. Field names are
+///   camelCase (`#[serde(rename_all = "camelCase")]`).
+/// - Listen for request and handle the returned value.
+///
+#[derive(Debug)]
+pub enum CompilationRequest {}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompilationRequestParams {
+    #[serde(flatten)]
+    pub text_document: TextDocumentIdentifier,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub enum CompilationType {
+    Spirv,
+    Dxil,
+    None,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub struct CompilationRequestResult {
+    pub ty: CompilationType,
+    pub data: Vec<u8>,
+}
+
+impl Request for CompilationRequest {
+    type Params = CompilationRequestParams;
+    type Result = Option<CompilationRequestResult>;
+    const METHOD: &'static str = "textDocument/compilationResult";
+}
+
+impl ServerLanguage {
+    pub fn recolt_compilation_result(
+        &self,
+        uri: &Url,
+    ) -> Result<Option<CompilationRequestResult>, ServerLanguageError> {
+        let cached_file = self.get_cachable_file(&uri)?;
+
+        if let Some(data) = &cached_file.data {
+            Ok(Some(CompilationRequestResult {
+                ty: match &data.compilation_cache {
+                    CompilationResult::None => CompilationType::None,
+                    CompilationResult::Dxil(_) => CompilationType::Dxil,
+                    CompilationResult::Spirv(_) => CompilationType::Spirv,
+                },
+                data: match &data.compilation_cache {
+                    CompilationResult::None => Vec::new(),
+                    CompilationResult::Dxil(dxil) => dxil.clone(),
+                    CompilationResult::Spirv(spirv) => spirv.clone(),
+                },
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/shader-language-server/src/server/provider/mod.rs
+++ b/shader-language-server/src/server/provider/mod.rs
@@ -1,3 +1,4 @@
+pub mod compilation;
 mod completion;
 mod diagnostic;
 mod document_symbol;

--- a/shader-language-server/src/server/server_config.rs
+++ b/shader-language-server/src/server/server_config.rs
@@ -14,7 +14,7 @@ use shader_sense::{
     shader::{
         GlslCompilationParams, GlslSpirvVersion, GlslTargetClient, HlslCompilationParams,
         HlslShaderModel, HlslVersion, ShaderCompilationParams, ShaderContextParams, ShaderParams,
-        ShaderStage, WgslCompilationParams,
+        ShaderStage, ShadingLanguage, WgslCompilationParams,
     },
     shader_error::ShaderDiagnosticSeverity,
 };
@@ -449,6 +449,13 @@ impl ServerConfig {
     }
     pub fn get_glsl_preamble_path(&self) -> Option<&PathBuf> {
         self.glsl.preamble_path.as_ref()
+    }
+    pub fn is_generating_spirv(&self, shading_language: ShadingLanguage) -> bool {
+        match shading_language {
+            ShadingLanguage::Wgsl => false,
+            ShadingLanguage::Hlsl => self.hlsl.spirv,
+            ShadingLanguage::Glsl => self.glsl.spirv != GlslSpirvVersion::None,
+        }
     }
     pub fn set_trace(&mut self, trace: ServerTrace) {
         self.trace = trace

--- a/shader-language-server/src/server/server_file_cache.rs
+++ b/shader-language-server/src/server/server_file_cache.rs
@@ -120,7 +120,7 @@ use shader_sense::{
         symbol_list::ShaderSymbolListRef,
         symbol_provider::SymbolProvider,
     },
-    validator::validator::ValidatorImpl,
+    validator::validator::{CompilationResult, ValidatorImpl},
 };
 
 use super::{server_config::ServerConfig, shader_variant::ShaderVariant};
@@ -130,6 +130,7 @@ pub struct ServerFileCacheData {
     pub symbol_cache: ShaderSymbols, // Store symbols to avoid computing them at every change.
     pub intrinsics: ShaderSymbolListRef<'static>, // Cached intrinsics to not recompute them everytime
     pub diagnostic_cache: ShaderDiagnosticList,   // Cached diagnostic
+    pub compilation_cache: CompilationResult,     // Cached compilation
 }
 
 #[derive(Debug, Clone)]
@@ -373,12 +374,12 @@ impl ServerLanguageFileCache {
             (ShaderSymbols::default(), ShaderDiagnosticList::default())
         };
         // Get diagnostics
-        let diagnostics = if config.get_validate() {
+        let (compilation, diagnostics) = if config.get_validate() {
             profile_scope!("Validating file {}", uri);
             let shading_language = self.files.get(uri).unwrap().shading_language;
             let shader_module = Rc::clone(&self.files.get(uri).unwrap().shader_module);
 
-            let mut diagnostic_list = {
+            let (compilation, mut diagnostic_list) = {
                 // TODO: should print warning if validation is too long.
                 profile_scope!("Raw validation");
                 let variant_shader_module = match &variant {
@@ -422,13 +423,13 @@ impl ServerLanguageFileCache {
                     },
                 ) {
                     Ok(diagnostics) => diagnostics,
-                    Err(err) => ShaderDiagnosticList { diagnostics: vec![
+                    Err(err) => (CompilationResult::None, ShaderDiagnosticList { diagnostics: vec![
                         ShaderDiagnostic {
                             severity: ShaderDiagnosticSeverity::Error,
                             error: format!("Failed to validate shader: {}", err),
                             range: ShaderFileRange::zero(file_path.clone())
                         }
-                    ]},
+                    ]}),
                 };
                 diagnostics
             };
@@ -490,9 +491,9 @@ impl ServerLanguageFileCache {
                     .diagnostics
                     .append(&mut ascended_diagnostics);
             }
-            diagnostic_list
+            (compilation, diagnostic_list)
         } else {
-            ShaderDiagnosticList::default()
+            (CompilationResult::None, ShaderDiagnosticList::default())
         };
 
         symbols
@@ -506,6 +507,7 @@ impl ServerLanguageFileCache {
             symbol_cache: symbols,
             intrinsics,
             diagnostic_cache: diagnostics,
+            compilation_cache: compilation,
         });
         Ok(())
     }
@@ -594,6 +596,7 @@ impl ServerLanguageFileCache {
                                             symbol_cache,
                                             intrinsics,
                                             diagnostic_cache,
+                                            compilation_cache: CompilationResult::None, // No compilation for deps
                                         },
                                     );
                                 }

--- a/shader-language-server/tests/server_communication.rs
+++ b/shader-language-server/tests/server_communication.rs
@@ -671,9 +671,9 @@ fn test_compilation_glsl_spirv() {
         |result| {
             let compilation = result.unwrap().unwrap();
             assert!(
-                compilation.ty == CompilationType::Spirv,
+                compilation.compilation_type == CompilationType::Spirv,
                 "Invalid compilation type: {:?}",
-                compilation.ty
+                compilation.compilation_type
             );
             assert!(
                 compilation.data.len() == 360,
@@ -734,9 +734,9 @@ fn test_compilation_hlsl_dxil() {
         |result| {
             let compilation = result.unwrap().unwrap();
             assert!(
-                compilation.ty == CompilationType::Dxil,
+                compilation.compilation_type == CompilationType::Dxil,
                 "Invalid compilation type: {:?}",
-                compilation.ty
+                compilation.compilation_type
             );
             assert!(
                 compilation.data.len() == 2672,

--- a/shader-language-server/tests/server_communication.rs
+++ b/shader-language-server/tests/server_communication.rs
@@ -666,6 +666,7 @@ fn test_compilation_glsl_spirv() {
     server.send_request::<CompilationRequest>(
         &CompilationRequestParams {
             text_document: file.identifier(),
+            compilation_type: None,
         },
         |result| {
             let compilation = result.unwrap().unwrap();
@@ -728,6 +729,7 @@ fn test_compilation_hlsl_dxil() {
     server.send_request::<CompilationRequest>(
         &CompilationRequestParams {
             text_document: file.identifier(),
+            compilation_type: None,
         },
         |result| {
             let compilation = result.unwrap().unwrap();

--- a/shader-language-server/tests/server_communication.rs
+++ b/shader-language-server/tests/server_communication.rs
@@ -24,6 +24,10 @@ use lsp_types::{
     DocumentDiagnosticReportResult, Hover, HoverParams, RelatedFullDocumentDiagnosticReport,
     SemanticTokensParams, SemanticTokensResult, WorkspaceSymbolParams, WorkspaceSymbolResponse,
 };
+use shader_language_server::server::provider::compilation::CompilationRequest;
+use shader_language_server::server::provider::compilation::{
+    CompilationRequestParams, CompilationType,
+};
 use shader_language_server::server::server_config::ServerSerializedConfig;
 use shader_language_server::server::shader_variant::{
     DidChangeShaderVariant, DidChangeShaderVariantParams, ShaderVariant,
@@ -613,6 +617,130 @@ fn test_semantic_tokens() {
             } else {
                 assert!(false);
             }
+        },
+    );
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: file.identifier(),
+    });
+}
+
+#[test]
+fn test_compilation_glsl_spirv() {
+    let mut server =
+        TestServer::desktop(ServerSerializedConfig::default(), Transport::Stdio).unwrap();
+
+    let file = TestFile::new(
+        Path::new("../shader-sense/test/glsl/ok.frag.glsl"),
+        ShadingLanguage::Glsl,
+    );
+    server.send_notification::<DidChangeShaderVariant>(&DidChangeShaderVariantParams {
+        shader_variant: Some(ShaderVariant {
+            url: file.url.clone(),
+            shading_language: ShadingLanguage::Glsl,
+            entry_point: "main".into(),
+            stage: Some(ShaderStage::Fragment),
+            defines: HashMap::new(),
+            includes: Vec::new(),
+        }),
+    });
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: file.item(),
+    });
+    server.send_request::<DocumentDiagnosticRequest>(
+        &DocumentDiagnosticParams {
+            text_document: file.identifier(),
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+        |report| {
+            let report = get_diagnostic_report(report.unwrap());
+            assert!(
+                report.full_document_diagnostic_report.items.is_empty(),
+                "Should not have any error with file, got {:#?}",
+                report.full_document_diagnostic_report.items
+            );
+        },
+    );
+    server.send_request::<CompilationRequest>(
+        &CompilationRequestParams {
+            text_document: file.identifier(),
+        },
+        |result| {
+            let compilation = result.unwrap().unwrap();
+            assert!(
+                compilation.ty == CompilationType::Spirv,
+                "Invalid compilation type: {:?}",
+                compilation.ty
+            );
+            assert!(
+                compilation.data.len() == 360,
+                "Invalid compilation length: {}",
+                compilation.data.len()
+            );
+        },
+    );
+    server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {
+        text_document: file.identifier(),
+    });
+}
+
+#[test]
+fn test_compilation_hlsl_dxil() {
+    let mut server =
+        TestServer::desktop(ServerSerializedConfig::default(), Transport::Stdio).unwrap();
+
+    let file = TestFile::new(
+        Path::new("../shader-sense/test/hlsl/ok.hlsl"),
+        ShadingLanguage::Hlsl,
+    );
+    server.send_notification::<DidChangeShaderVariant>(&DidChangeShaderVariantParams {
+        shader_variant: Some(ShaderVariant {
+            url: file.url.clone(),
+            shading_language: ShadingLanguage::Hlsl,
+            entry_point: "fs_main".into(),
+            stage: Some(ShaderStage::Fragment),
+            defines: HashMap::new(),
+            includes: Vec::new(),
+        }),
+    });
+    server.send_notification::<DidOpenTextDocument>(&DidOpenTextDocumentParams {
+        text_document: file.item(),
+    });
+    server.send_request::<DocumentDiagnosticRequest>(
+        &DocumentDiagnosticParams {
+            text_document: file.identifier(),
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        },
+        |report| {
+            let report = get_diagnostic_report(report.unwrap());
+            assert!(
+                report.full_document_diagnostic_report.items.is_empty(),
+                "Should not have any error with file, got {:#?}",
+                report.full_document_diagnostic_report.items
+            );
+        },
+    );
+    server.send_request::<CompilationRequest>(
+        &CompilationRequestParams {
+            text_document: file.identifier(),
+        },
+        |result| {
+            let compilation = result.unwrap().unwrap();
+            assert!(
+                compilation.ty == CompilationType::Dxil,
+                "Invalid compilation type: {:?}",
+                compilation.ty
+            );
+            assert!(
+                compilation.data.len() == 2672,
+                "Invalid compilation length: {}",
+                compilation.data.len()
+            );
         },
     );
     server.send_notification::<DidCloseTextDocument>(&DidCloseTextDocumentParams {

--- a/shader-sense-cli/src/main.rs
+++ b/shader-sense-cli/src/main.rs
@@ -17,6 +17,7 @@
 //! --constants               List constants
 //! --keywords                List keywords
 //! --types                   List types
+//! --output <FILE>           Save output to specified file
 //! --version, -v             Print version information
 //! --help, -h                Print this message
 //! ```
@@ -45,7 +46,7 @@ use shader_sense::{
         symbol_provider::SymbolProvider,
         symbols::{ShaderSymbolMode, ShaderSymbolType},
     },
-    validator::validator::Validator,
+    validator::validator::{CompilationResult, Validator},
 };
 
 fn get_version() -> &'static str {
@@ -80,6 +81,7 @@ pub fn usage() {
     println!("  --constants               List constants");
     println!("  --keywords                List keywords");
     println!("  --types                   List types");
+    println!("  --output <FILE>           Save output to specified file");
     println!("  --version, -v             Print version information");
     println!("  --help, -h                Print this message");
     println!();
@@ -100,6 +102,7 @@ pub fn main() {
     let mut entry_point = None;
     let mut shader_stage = None;
     let mut experimental_macro_expansion = false;
+    let mut output: Option<PathBuf> = None;
     let mut target_client = GlslTargetClient::Vulkan1_3;
     let _exe = args.next().unwrap();
     while let Some(arg) = args.next() {
@@ -207,6 +210,16 @@ pub fn main() {
             "--expand-macro" => {
                 experimental_macro_expansion = true;
             }
+            "--output" => match args.next() {
+                Some(path) => {
+                    should_validate = true;
+                    output = Some(PathBuf::from(path))
+                }
+                None => {
+                    println!("Missing output file name");
+                    usage();
+                }
+            },
             parsed_file_name => match &mut file_name {
                 Some(_) => usage(),
                 None => {
@@ -262,7 +275,7 @@ pub fn main() {
                     &shader_params,
                     &mut |path: &Path| Some(std::fs::read_to_string(path).unwrap()),
                 ) {
-                    Ok(diagnostic_list) => {
+                    Ok((blob, diagnostic_list)) => {
                         if diagnostic_list.is_empty() {
                             println!(
                                 "{}",
@@ -295,6 +308,29 @@ pub fn main() {
                                     }
                                 };
                                 println!("{}\n{}", header, diagnostic.error.italic());
+                            }
+                        }
+                        if let Some(output) = output {
+                            let blob = match blob {
+                                CompilationResult::None => Vec::new(),
+                                CompilationResult::Spirv(spirv) => spirv,
+                                CompilationResult::Dxil(dxil) => dxil,
+                            };
+                            if !blob.is_empty() {
+                                if let Err(err) = std::fs::write(&output, &blob) {
+                                    println!(
+                                        "{}",
+                                        format!(
+                                            "Failed to save output to file {}: {}",
+                                            output.display(),
+                                            err
+                                        )
+                                        .red()
+                                        .bold()
+                                    );
+                                }
+                            } else {
+                                println!("{}", "No output generated".red().bold());
                             }
                         }
                     }

--- a/shader-sense-cli/src/main.rs
+++ b/shader-sense-cli/src/main.rs
@@ -315,6 +315,7 @@ pub fn main() {
                                 CompilationResult::None => Vec::new(),
                                 CompilationResult::Spirv(spirv) => spirv,
                                 CompilationResult::Dxil(dxil) => dxil,
+                                CompilationResult::Wgsl(wgsl) => wgsl.into_bytes(),
                             };
                             if !blob.is_empty() {
                                 if let Err(err) = std::fs::write(&output, &blob) {

--- a/shader-sense/Cargo.toml
+++ b/shader-sense/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.89" # Minimal version required for wasm C ABI https://github.c
 
 [dependencies]
 glslang = "0.6.1"
-naga = { version = "24.0.0", features = ["wgsl-in"] }
+naga = { version = "24.0.0", features = ["wgsl-in", "wgsl-out", "spv-out", "spv-in"] }
 regex = "1.10.4"
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"

--- a/shader-sense/examples/main.rs
+++ b/shader-sense/examples/main.rs
@@ -18,7 +18,7 @@ fn validate_file<T: ShadingLanguageTag>(shader_path: &Path, shader_content: &str
         &ShaderParams::default(),
         &mut |path: &Path| Some(std::fs::read_to_string(path).unwrap()),
     ) {
-        Ok(diagnostic_list) => println!(
+        Ok((_blob, diagnostic_list)) => println!(
             "Validated file and return following diagnostics: {:#?}",
             diagnostic_list
         ),

--- a/shader-sense/src/lib.rs
+++ b/shader-sense/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
             &ShaderParams::default(),
             &mut |path| Some(std::fs::read_to_string(path).unwrap()),
         ) {
-            Ok(diagnostics) => assert!(
+            Ok((_blob, diagnostics)) => assert!(
                 !diagnostics.is_empty(),
                 "Diagnostics are empty but should not be."
             ),

--- a/shader-sense/src/symbols/shader_module_parser.rs
+++ b/shader-sense/src/symbols/shader_module_parser.rs
@@ -20,8 +20,8 @@ use super::shader_module::ShaderModule;
 /// shader_module_parser.update_module_partial(
 ///     &mut shader_module,
 ///     &ShaderRange::new(
-///         ShaderPosition::new(3, 4),
-///         ShaderPosition::new(3, 4)
+///         ShaderPosition::new(2, 4),
+///         ShaderPosition::new(2, 4)
 ///     ),
 ///     &String::from("inserted text")
 /// ).unwrap();

--- a/shader-sense/src/validator/dxc.rs
+++ b/shader-sense/src/validator/dxc.rs
@@ -11,6 +11,7 @@ use crate::{
     position::{ShaderFileRange, ShaderPosition},
     shader::{HlslShaderModel, HlslVersion, ShaderParams, ShaderStage},
     shader_error::{ShaderDiagnostic, ShaderDiagnosticList, ShaderDiagnosticSeverity, ShaderError},
+    validator::validator::CompilationResult,
 };
 
 use super::validator::ValidatorImpl;
@@ -269,6 +270,22 @@ impl Dxc {
             ))),
         }
     }
+    fn get_compilation_result(
+        &self,
+        shader_params: &ShaderParams,
+        result: DxcOperationResult,
+    ) -> CompilationResult {
+        match result.get_result() {
+            Ok(blob) => {
+                if shader_params.compilation.hlsl.spirv {
+                    CompilationResult::Spirv(blob.to_vec())
+                } else {
+                    CompilationResult::Dxil(blob.to_vec())
+                }
+            }
+            Err(_) => CompilationResult::None,
+        }
+    }
 }
 
 fn get_profile(shader_stage: Option<ShaderStage>) -> &'static str {
@@ -304,7 +321,7 @@ impl ValidatorImpl for Dxc {
         file_path: &Path,
         params: &ShaderParams,
         include_callback: &mut dyn FnMut(&Path) -> Option<String>,
-    ) -> Result<ShaderDiagnosticList, ShaderError> {
+    ) -> Result<(CompilationResult, ShaderDiagnosticList), ShaderError> {
         let file_name = self.get_file_name(file_path);
 
         let blob = match self
@@ -313,7 +330,7 @@ impl ValidatorImpl for Dxc {
         {
             Ok(blob) => blob,
             Err(err) => match self.from_hassle_error(err, file_path, &params) {
-                Ok(diagnostics) => return Ok(diagnostics),
+                Ok(diagnostics) => return Ok((CompilationResult::None, diagnostics)),
                 Err(error) => return Err(error),
             },
         };
@@ -400,14 +417,24 @@ impl ValidatorImpl for Dxc {
                 let error_blob = match dxc_result.get_error_buffer() {
                     Ok(blob) => blob,
                     Err(err) => match self.from_hassle_error(err, file_path, &params) {
-                        Ok(diagnostics) => return Ok(diagnostics),
+                        Ok(diagnostics) => {
+                            return Ok((
+                                self.get_compilation_result(params, dxc_result),
+                                diagnostics,
+                            ))
+                        }
                         Err(error) => return Err(error),
                     },
                 };
                 let warning_emitted = match self.library.get_blob_as_string(&error_blob.into()) {
                     Ok(string) => string,
                     Err(err) => match self.from_hassle_error(err, file_path, &params) {
-                        Ok(diagnostics) => return Ok(diagnostics),
+                        Ok(diagnostics) => {
+                            return Ok((
+                                self.get_compilation_result(params, dxc_result),
+                                diagnostics,
+                            ))
+                        }
                         Err(error) => return Err(error),
                     },
                 };
@@ -424,7 +451,10 @@ impl ValidatorImpl for Dxc {
                     Ok(blob) => blob,
                     Err(err) => match self.from_hassle_error(err, file_path, &params) {
                         Ok(diagnostics) => {
-                            return Ok(ShaderDiagnosticList::join(warning_diagnostics, diagnostics))
+                            return Ok((
+                                self.get_compilation_result(params, dxc_result),
+                                ShaderDiagnosticList::join(warning_diagnostics, diagnostics),
+                            ))
                         }
                         Err(error) => return Err(error),
                     },
@@ -439,47 +469,69 @@ impl ValidatorImpl for Dxc {
                                 Ok(blob) => blob,
                                 Err(err) => match self.from_hassle_error(err, file_path, &params) {
                                     Ok(diagnostics) => {
-                                        return Ok(ShaderDiagnosticList::join(
-                                            warning_diagnostics,
-                                            diagnostics,
+                                        return Ok((
+                                            CompilationResult::Dxil(data),
+                                            ShaderDiagnosticList::join(
+                                                warning_diagnostics,
+                                                diagnostics,
+                                            ),
                                         ))
                                     }
                                     Err(error) => return Err(error),
                                 },
                             };
                         match validator.validate(blob_encoding.into()) {
-                            Ok(_) => Ok(warning_diagnostics),
+                            Ok(_) => Ok((CompilationResult::Dxil(data), warning_diagnostics)),
                             Err((_dxc_res, hassle_err)) => {
                                 //let error_blob = dxc_err.0.get_error_buffer().map_err(|e| self.from_hassle_error(e))?;
                                 //let error_emitted = self.library.get_blob_as_string(&error_blob.into()).map_err(|e| self.from_hassle_error(e))?;
                                 match self.from_hassle_error(hassle_err, file_path, &params) {
-                                    Ok(diagnostics) => Ok(ShaderDiagnosticList::join(
-                                        warning_diagnostics,
-                                        diagnostics,
+                                    Ok(diagnostics) => Ok((
+                                        CompilationResult::Dxil(data),
+                                        ShaderDiagnosticList::join(
+                                            warning_diagnostics,
+                                            diagnostics,
+                                        ),
                                     )),
                                     Err(err) => Err(err),
                                 }
                             }
                         }
                     } else {
-                        Ok(warning_diagnostics)
+                        Ok((
+                            self.get_compilation_result(params, dxc_result),
+                            warning_diagnostics,
+                        ))
                     }
                 } else {
-                    Ok(warning_diagnostics)
+                    Ok((
+                        self.get_compilation_result(params, dxc_result),
+                        warning_diagnostics,
+                    ))
                 }
             }
             Err((dxc_result, _hresult)) => {
                 let error_blob = match dxc_result.get_error_buffer() {
                     Ok(blob) => blob,
                     Err(err) => match self.from_hassle_error(err, file_path, &params) {
-                        Ok(diagnostics) => return Ok(diagnostics),
+                        Ok(diagnostics) => {
+                            return Ok((
+                                self.get_compilation_result(params, dxc_result),
+                                diagnostics,
+                            ))
+                        }
                         Err(error) => return Err(error),
                     },
                 };
                 let error_emitted = match self.library.get_blob_as_string(&error_blob.into()) {
                     Ok(string) => string,
                     Err(err) => match self.from_hassle_error(err, file_path, &params) {
-                        Ok(diagnostics) => return Ok(diagnostics),
+                        Ok(diagnostics) => {
+                            return Ok((
+                                self.get_compilation_result(params, dxc_result),
+                                diagnostics,
+                            ))
+                        }
                         Err(error) => return Err(error),
                     },
                 };
@@ -488,7 +540,7 @@ impl ValidatorImpl for Dxc {
                     file_path,
                     &params,
                 ) {
-                    Ok(diag) => Ok(diag),
+                    Ok(diag) => Ok((self.get_compilation_result(params, dxc_result), diag)),
                     Err(error) => Err(error),
                 }
             }

--- a/shader-sense/src/validator/glslang.rs
+++ b/shader-sense/src/validator/glslang.rs
@@ -6,6 +6,7 @@ use crate::{
     position::{ShaderFileRange, ShaderPosition},
     shader::{GlslSpirvVersion, GlslTargetClient, ShaderParams, ShaderStage},
     shader_error::{ShaderDiagnostic, ShaderDiagnosticList, ShaderDiagnosticSeverity, ShaderError},
+    validator::validator::CompilationResult,
 };
 use glslang::{
     error::GlslangError,
@@ -261,7 +262,7 @@ impl ValidatorImpl for Glslang {
         file_path: &Path,
         params: &ShaderParams,
         include_callback: &mut dyn FnMut(&Path) -> Option<String>,
-    ) -> Result<ShaderDiagnosticList, ShaderError> {
+    ) -> Result<(CompilationResult, ShaderDiagnosticList), ShaderError> {
         let file_name = self.get_file_name(file_path);
 
         // Ensure we have a newline character at the end to avoid issues with offset.
@@ -409,7 +410,7 @@ impl ValidatorImpl for Glslang {
             Ok(value) => value,
             Err(error) => match error {
                 Err(error) => return Err(error),
-                Ok(diag) => return Ok(diag),
+                Ok(diag) => return Ok((CompilationResult::None, diag)),
             },
         };
         let _shader = match glslang::Shader::new(&self.compiler, input)
@@ -418,25 +419,31 @@ impl ValidatorImpl for Glslang {
             Ok(value) => value,
             Err(error) => match error {
                 Err(error) => return Err(error),
-                Ok(diag) => return Ok(diag),
+                Ok(diag) => return Ok((CompilationResult::None, diag)),
             },
         };
         // Linking require main entry point.
-        // For now, glslang is expecting main entry point, no way to change this via C api.
-        /*if params.entry_point.is_some() {
-            let _spirv = match shader
-                .compile()
-                .map_err(|e| self.from_glslang_error(e, file_path, &params, offset_first_line))
-            {
-                Ok(value) => value,
-                Err(error) => match error {
-                    Err(error) => return Err(error),
-                    Ok(diag) => return Ok(diag),
-                },
-            };
-        }*/
-
-        Ok(ShaderDiagnosticList::empty()) // No error detected.
+        // For now, glslang is expecting main entry point, no way to change this via C api yet.
+        let mut spirv = match _shader
+            .compile()
+            .map_err(|e| self.from_glslang_error(e, file_path, &params, preamble_line_offset))
+        {
+            Ok(value) => value,
+            Err(error) => match error {
+                Err(error) => return Err(error),
+                Ok(diag) => return Ok((CompilationResult::None, diag)),
+            },
+        };
+        // Safe because u32 multiple of u8
+        let compilation_result = if !spirv.is_empty() {
+            let ptr = spirv.as_mut_ptr() as *mut u8;
+            let length = spirv.len() * std::mem::size_of::<u32>();
+            std::mem::forget(spirv);
+            CompilationResult::Spirv(unsafe { Vec::<u8>::from_raw_parts(ptr, length, length) })
+        } else {
+            CompilationResult::None
+        };
+        Ok((compilation_result, ShaderDiagnosticList::empty())) // No error detected.
     }
     fn support(&self, shader_stage: ShaderStage) -> bool {
         if self.hlsl {

--- a/shader-sense/src/validator/glslang.rs
+++ b/shader-sense/src/validator/glslang.rs
@@ -413,7 +413,7 @@ impl ValidatorImpl for Glslang {
                 Ok(diag) => return Ok((CompilationResult::None, diag)),
             },
         };
-        let _shader = match glslang::Shader::new(&self.compiler, input)
+        let shader = match glslang::Shader::new(&self.compiler, input)
             .map_err(|e| self.from_glslang_error(e, file_path, &params, preamble_line_offset))
         {
             Ok(value) => value,
@@ -422,26 +422,37 @@ impl ValidatorImpl for Glslang {
                 Ok(diag) => return Ok((CompilationResult::None, diag)),
             },
         };
-        // Linking require main entry point.
         // For now, glslang is expecting main entry point, no way to change this via C api yet.
-        let mut spirv = match _shader
-            .compile()
-            .map_err(|e| self.from_glslang_error(e, file_path, &params, preamble_line_offset))
-        {
-            Ok(value) => value,
-            Err(error) => match error {
-                Err(error) => return Err(error),
-                Ok(diag) => return Ok((CompilationResult::None, diag)),
-            },
-        };
-        // Safe because u32 multiple of u8
-        let compilation_result = if !spirv.is_empty() {
-            let ptr = spirv.as_mut_ptr() as *mut u8;
-            let length = spirv.len() * std::mem::size_of::<u32>();
-            std::mem::forget(spirv);
-            CompilationResult::Spirv(unsafe { Vec::<u8>::from_raw_parts(ptr, length, length) })
+        // Linking require a valid entry point, so skipping it for validation.
+        let compilation_result = if let Some(entry_point) = &params.compilation.entry_point {
+            // For now, only compile main entry point as we cannot compile any other without changes to GLSLang
+            if entry_point == "main" {
+                let mut spirv = match shader.compile().map_err(|e| {
+                    self.from_glslang_error(e, file_path, &params, preamble_line_offset)
+                }) {
+                    Ok(value) => value,
+                    Err(error) => match error {
+                        Err(error) => return Err(error),
+                        Ok(diag) => return Ok((CompilationResult::None, diag)),
+                    },
+                };
+                // Safe because u32 multiple of u8
+                let compilation_result = if !spirv.is_empty() {
+                    let ptr = spirv.as_mut_ptr() as *mut u8;
+                    let length = spirv.len() * std::mem::size_of::<u32>();
+                    std::mem::forget(spirv);
+                    CompilationResult::Spirv(unsafe {
+                        Vec::<u8>::from_raw_parts(ptr, length, length)
+                    })
+                } else {
+                    CompilationResult::None
+                };
+                compilation_result
+            } else {
+                CompilationResult::None
+            }
         } else {
-            CompilationResult::None
+            CompilationResult::None // No compilation.
         };
         Ok((compilation_result, ShaderDiagnosticList::empty())) // No error detected.
     }

--- a/shader-sense/src/validator/mod.rs
+++ b/shader-sense/src/validator/mod.rs
@@ -49,9 +49,9 @@ mod tests {
             &ShaderParams::default(),
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostics)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostics);
+                assert!(diagnostics.is_empty())
             }
             Err(err) => panic!("{}", err),
         }
@@ -74,9 +74,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -99,9 +99,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -124,9 +124,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -149,9 +149,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -168,8 +168,8 @@ mod tests {
             &ShaderParams::default(),
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                let diags = result.diagnostics;
+            Ok((_blob, diagnostic_list)) => {
+                let diags = diagnostic_list.diagnostics;
                 println!("Diagnostic should not be empty: {:#?}", diags);
                 assert!(diags[0].range.file_path.exists());
                 assert_eq!(diags[0].error, String::from(" '#include' : Could not process include directive for header name: ./level1.glsl\n"));
@@ -189,9 +189,9 @@ mod tests {
             &ShaderParams::default(),
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should not be empty: {:#?}", result);
-                assert!(!result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should not be empty: {:#?}", diagnostic_list);
+                assert!(!diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -220,9 +220,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -251,9 +251,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -282,9 +282,20 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((blob, diagnostic_list)) => {
+                assert!(
+                    diagnostic_list.is_empty(),
+                    "Diagnostic should be empty: {:#?}",
+                    diagnostic_list
+                );
+                assert!(
+                    match &blob {
+                        CompilationResult::Spirv(blob) => !blob.is_empty(),
+                        _ => false, // Only expect SpirV
+                    },
+                    "Blob should not be empty: {:?}",
+                    blob
+                );
             }
             Err(err) => panic!("{}", err),
         };
@@ -313,9 +324,12 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                assert!(
+                    diagnostic_list.is_empty(),
+                    "Diagnostic should be empty: {:#?}",
+                    diagnostic_list
+                );
             }
             Err(err) => panic!("{}", err),
         };
@@ -344,9 +358,12 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                assert!(
+                    diagnostic_list.is_empty(),
+                    "Diagnostic should be empty: {:#?}",
+                    diagnostic_list
+                );
             }
             Err(err) => panic!("{}", err),
         };
@@ -363,9 +380,20 @@ mod tests {
             &ShaderParams::default(),
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((blob, diagnostic_list)) => {
+                assert!(
+                    diagnostic_list.is_empty(),
+                    "Diagnostic should be empty: {:#?}",
+                    diagnostic_list
+                );
+                assert!(
+                    match &blob {
+                        CompilationResult::Dxil(blob) => !blob.is_empty(),
+                        _ => false, // Only expect Dxil
+                    },
+                    "Blob should not be empty: {:?}",
+                    blob
+                );
             }
             Err(err) => panic!("{}", err),
         };
@@ -388,9 +416,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -413,9 +441,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -443,9 +471,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -468,9 +496,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -499,9 +527,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -531,9 +559,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should not be empty: {:#?}", result);
-                assert!(!result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should not be empty: {:#?}", diagnostic_list);
+                assert!(!diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -553,9 +581,9 @@ mod tests {
             },
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };
@@ -597,12 +625,13 @@ mod tests {
                 },
                 &mut default_include_callback,
             ) {
-                Ok(result) => {
-                    println!(
+                Ok((_blob, diagnostic_list)) => {
+                    assert!(
+                        diagnostic_list.is_empty(),
                         "Diagnostic should be empty for stage {:?}: {:#?}",
-                        shader_stage, result
-                    );
-                    assert!(result.is_empty())
+                        shader_stage,
+                        diagnostic_list
+                    )
                 }
                 Err(err) => panic!("{}", err),
             };
@@ -648,12 +677,12 @@ mod tests {
                     },
                     &mut default_include_callback,
                 ) {
-                    Ok(result) => {
+                    Ok((_blob, diagnostic_list)) => {
                         println!(
                             "Diagnostic should be empty for stage {:?}: {:#?}",
-                            shader_stage, result
+                            shader_stage, diagnostic_list
                         );
-                        assert!(result.is_empty())
+                        assert!(diagnostic_list.is_empty())
                     }
                     Err(err) => panic!("{}", err),
                 };
@@ -691,12 +720,12 @@ mod tests {
                 },
                 &mut default_include_callback,
             ) {
-                Ok(result) => {
+                Ok((_blob, diagnostic_list)) => {
                     println!(
                         "Diagnostic should be empty for stage {:?}: {:#?}",
-                        shader_stage, result
+                        shader_stage, diagnostic_list
                     );
-                    assert!(result.is_empty())
+                    assert!(diagnostic_list.is_empty())
                 }
                 Err(err) => panic!("{}", err),
             };
@@ -714,9 +743,9 @@ mod tests {
             &ShaderParams::default(),
             &mut default_include_callback,
         ) {
-            Ok(result) => {
-                println!("Diagnostic should be empty: {:#?}", result);
-                assert!(result.is_empty())
+            Ok((_blob, diagnostic_list)) => {
+                println!("Diagnostic should be empty: {:#?}", diagnostic_list);
+                assert!(diagnostic_list.is_empty())
             }
             Err(err) => panic!("{}", err),
         };

--- a/shader-sense/src/validator/mod.rs
+++ b/shader-sense/src/validator/mod.rs
@@ -391,7 +391,7 @@ mod tests {
                         #[cfg(not(target_os = "wasi"))]
                         CompilationResult::Dxil(blob) => !blob.is_empty(),
                         #[cfg(target_os = "wasi")]
-                        CompilationResult::Spirv(blob) => !blob.is_empty(),
+                        CompilationResult::None => true, // No compilation result on wasi.
                         _ => false, // Only expect Dxil
                     },
                     "Blob should not be empty: {:?}",

--- a/shader-sense/src/validator/mod.rs
+++ b/shader-sense/src/validator/mod.rs
@@ -388,7 +388,10 @@ mod tests {
                 );
                 assert!(
                     match &blob {
+                        #[cfg(not(target_os = "wasi"))]
                         CompilationResult::Dxil(blob) => !blob.is_empty(),
+                        #[cfg(target_os = "wasi")]
+                        CompilationResult::Spirv(blob) => !blob.is_empty(),
                         _ => false, // Only expect Dxil
                     },
                     "Blob should not be empty: {:?}",

--- a/shader-sense/src/validator/mod.rs
+++ b/shader-sense/src/validator/mod.rs
@@ -750,4 +750,20 @@ mod tests {
             Err(err) => panic!("{}", err),
         };
     }
+
+    #[test]
+    fn wgsl_spirv_conversion() {
+        let file_path = Path::new("./test/wgsl/ok.wgsl");
+        let shader_content = std::fs::read_to_string(file_path).unwrap();
+        let spirv = match naga::Naga::wgsl_to_spirv(&shader_content) {
+            Ok(spirv) => spirv,
+            Err(err) => panic!("{}", err),
+        };
+        assert!(!spirv.is_empty());
+        match naga::Naga::spirv_to_wgsl(&spirv) {
+            // Generated wgsl is not the same as the input one, but should hold the same entry point.
+            Ok(wgsl) => assert!(wgsl.contains("vs_main"), "Unexpected wgsl output: {}", wgsl),
+            Err(err) => panic!("{}", err),
+        };
+    }
 }

--- a/shader-sense/src/validator/mod.rs
+++ b/shader-sense/src/validator/mod.rs
@@ -269,7 +269,7 @@ mod tests {
             file_path,
             &ShaderParams {
                 compilation: ShaderCompilationParams {
-                    entry_point: None,
+                    entry_point: Some("main".into()), // TODO: should not require this and induce main as entry point if not set for compile
                     shader_stage: Some(ShaderStage::Vertex),
                     glsl: GlslCompilationParams {
                         client: GlslTargetClient::Vulkan1_3,

--- a/shader-sense/src/validator/naga.rs
+++ b/shader-sense/src/validator/naga.rs
@@ -10,6 +10,7 @@ use crate::{
     position::{ShaderFileRange, ShaderPosition},
     shader::{ShaderParams, ShaderStage},
     shader_error::{ShaderDiagnostic, ShaderDiagnosticList, ShaderDiagnosticSeverity, ShaderError},
+    validator::validator::CompilationResult,
 };
 
 use super::validator::ValidatorImpl;
@@ -49,13 +50,13 @@ impl ValidatorImpl for Naga {
         file_path: &Path,
         _params: &ShaderParams,
         _include_callback: &mut dyn FnMut(&Path) -> Option<String>,
-    ) -> Result<ShaderDiagnosticList, ShaderError> {
+    ) -> Result<(CompilationResult, ShaderDiagnosticList), ShaderError> {
         let module = match wgsl::parse_str(shader_content)
             .map_err(|err| Self::from_parse_err(err, file_path, shader_content))
         {
             Ok(module) => module,
             Err(diag) => {
-                return Ok(ShaderDiagnosticList::from(diag));
+                return Ok((CompilationResult::None, ShaderDiagnosticList::from(diag)));
             }
         };
 
@@ -80,10 +81,11 @@ impl ValidatorImpl for Naga {
                     error.emit_to_string(shader_content),
                 ))
             } else {
-                Ok(list)
+                Ok((CompilationResult::None, list))
             }
         } else {
-            Ok(ShaderDiagnosticList::empty())
+            // Wgsl compile to itself
+            Ok((CompilationResult::None, ShaderDiagnosticList::empty()))
         }
     }
     fn support(&self, shader_stage: ShaderStage) -> bool {

--- a/shader-sense/src/validator/naga.rs
+++ b/shader-sense/src/validator/naga.rs
@@ -42,6 +42,56 @@ impl Naga {
             }
         }
     }
+    /// Convert a SPIR-V binary module to its WGSL representation.
+    pub fn spirv_to_wgsl(spirv: &[u8]) -> Result<String, ShaderError> {
+        // TODO: Option should change depending on target spirv version (adjust_coordinate_space which is > SPV1.0).
+        let module = naga::front::spv::parse_u8_slice(spirv, &naga::front::spv::Options::default())
+            .map_err(|err| {
+                ShaderError::ValidationError(format!("Failed to parse SPIR-V module: {}", err))
+            })?;
+        let mut validator =
+            naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all());
+        let module_info = validator.validate(&module).map_err(|err| {
+            ShaderError::ValidationError(format!(
+                "Failed to validate SPIR-V module: {}",
+                err.emit_to_string("")
+            ))
+        })?;
+        naga::back::wgsl::write_string(
+            &module,
+            &module_info,
+            naga::back::wgsl::WriterFlags::empty(),
+        )
+        .map_err(|err| ShaderError::InternalErr(format!("Failed to write WGSL: {}", err)))
+    }
+    /// Convert a WGSL shader to its SPIR-V binary representation.
+    pub fn wgsl_to_spirv(shader_content: &str) -> Result<Vec<u8>, ShaderError> {
+        let module = wgsl::parse_str(shader_content).map_err(|err| {
+            ShaderError::ValidationError(format!(
+                "Failed to parse WGSL module: {}",
+                err.emit_to_string(shader_content)
+            ))
+        })?;
+        let mut validator =
+            naga::valid::Validator::new(ValidationFlags::all(), Capabilities::all());
+        let module_info = validator.validate(&module).map_err(|err| {
+            ShaderError::ValidationError(format!(
+                "Failed to validate WGSL module: {}",
+                err.emit_to_string(shader_content)
+            ))
+        })?;
+        let words = naga::back::spv::write_vec(
+            &module,
+            &module_info,
+            &naga::back::spv::Options::default(),
+            None, // Emit every entry point.
+        )
+        .map_err(|err| {
+            ShaderError::InternalErr(format!("Failed to write SPIR-V module: {}", err))
+        })?;
+        // Little endian, to match what naga::front::spv expects.
+        Ok(words.iter().flat_map(|word| word.to_le_bytes()).collect())
+    }
 }
 impl ValidatorImpl for Naga {
     fn validate_shader(
@@ -85,7 +135,10 @@ impl ValidatorImpl for Naga {
             }
         } else {
             // Wgsl compile to itself
-            Ok((CompilationResult::None, ShaderDiagnosticList::empty()))
+            Ok((
+                CompilationResult::Wgsl(shader_content.into()),
+                ShaderDiagnosticList::empty(),
+            ))
         }
     }
     fn support(&self, shader_stage: ShaderStage) -> bool {

--- a/shader-sense/src/validator/validator.rs
+++ b/shader-sense/src/validator/validator.rs
@@ -20,6 +20,7 @@ pub enum CompilationResult {
     None,
     Spirv(Vec<u8>),
     Dxil(Vec<u8>),
+    Wgsl(String),
 }
 
 /// Trait that all validator must implement to validate files.

--- a/shader-sense/src/validator/validator.rs
+++ b/shader-sense/src/validator/validator.rs
@@ -14,6 +14,14 @@ pub fn default_include_callback(path: &Path) -> Option<String> {
     Some(std::fs::read_to_string(path).unwrap())
 }
 
+#[derive(Debug, Clone, Default)]
+pub enum CompilationResult {
+    #[default]
+    None,
+    Spirv(Vec<u8>),
+    Dxil(Vec<u8>),
+}
+
 /// Trait that all validator must implement to validate files.
 pub trait ValidatorImpl {
     fn validate_shader(
@@ -22,7 +30,7 @@ pub trait ValidatorImpl {
         file_path: &Path,
         params: &ShaderParams,
         include_callback: &mut dyn FnMut(&Path) -> Option<String>,
-    ) -> Result<ShaderDiagnosticList, ShaderError>;
+    ) -> Result<(CompilationResult, ShaderDiagnosticList), ShaderError>;
 
     fn support(&self, shader_stage: ShaderStage) -> bool;
 
@@ -100,7 +108,7 @@ impl Validator {
         file_path: &Path,
         params: &ShaderParams,
         include_callback: &mut dyn FnMut(&Path) -> Option<String>, // TODO: Check if we cant pass a ref instead of a copy here.
-    ) -> Result<ShaderDiagnosticList, ShaderError> {
+    ) -> Result<(CompilationResult, ShaderDiagnosticList), ShaderError> {
         self.imp
             .validate_shader(shader_content, file_path, params, include_callback)
     }

--- a/shader-sense/test/hlsl/ok.hlsl
+++ b/shader-sense/test/hlsl/ok.hlsl
@@ -1,6 +1,4 @@
-#include "inc0/level0.hlsl"
-
-float4 fs_main(uint3 dtid : SV_DispatchThreadID) : SV_RenderTarget0 {
+float4 fs_main(in float4 color : COLOR) : SV_Target0 {
     
-    return float4(level0,1,1,0);
+    return float4(0,1,1,0);
 }


### PR DESCRIPTION
Now server add a `textDocument/compilationResult` request to request the server for a compilation result for a given shader. It needs to be a variant for it to work correctly